### PR TITLE
Fixed test failures and positional param logic between native and jpa-styles

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -484,6 +484,11 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 
 	@Override
 	public Parameter<?> getParameter(int position) {
+		// lookup jpa-based positional parameters first by name.
+		if ( parameterMetadata.getPositionalParameterCount() == 0 ) {
+			return parameterMetadata.getQueryParameter( String.valueOf( position ) );
+		}
+		// fallback to oridinal lookup
 		return parameterMetadata.getQueryParameter( position );
 	}
 


### PR DESCRIPTION
Fixed failing tests and code to treat '?' parameters as 0-based ordinals and '?<position>' parameters as named 1-based parameters.