### PR TITLE
Fix JTA transaction access and new SPI method accessTransaction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -60,6 +60,7 @@ import org.hibernate.tuple.entity.EntityTuplizerFactory;
 import org.jboss.logging.Logger;
 
 import static org.hibernate.cfg.AvailableSettings.ACQUIRE_CONNECTIONS;
+import static org.hibernate.cfg.AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS;
 import static org.hibernate.cfg.AvailableSettings.AUTO_CLOSE_SESSION;
 import static org.hibernate.cfg.AvailableSettings.AUTO_EVICT_COLLECTION_CACHE;
 import static org.hibernate.cfg.AvailableSettings.AUTO_SESSION_EVENTS_LISTENER;
@@ -481,6 +482,11 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
+	public void disableJtaTransactionAccess() {
+		this.options.jtaTransactionAccessEnabled = false;
+	}
+
+	@Override
 	public SessionFactoryOptions buildSessionFactoryOptions() {
 		return new SessionFactoryOptionsImpl( this );
 	}
@@ -504,6 +510,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		// Session behavior
 		private boolean flushBeforeCompletionEnabled;
 		private boolean autoCloseSessionEnabled;
+		private boolean jtaTransactionAccessEnabled;
 
 		// (JTA) transaction handling
 		private boolean jtaTrackByThread;
@@ -591,6 +598,11 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 			this.sessionFactoryName = (String) configurationSettings.get( SESSION_FACTORY_NAME );
 			this.sessionFactoryNameAlsoJndiName = cfgService.getSetting(
 					SESSION_FACTORY_NAME_IS_JNDI,
+					BOOLEAN,
+					true
+			);
+			this.jtaTransactionAccessEnabled = cfgService.getSetting(
+					ALLOW_JTA_TRANSACTION_ACCESS,
 					BOOLEAN,
 					true
 			);
@@ -846,6 +858,11 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		@Override
 		public boolean isJpaBootstrap() {
 			return jpaBootstrap;
+		}
+
+		@Override
+		public boolean isJtaTransactionAccessEnabled() {
+			return jtaTransactionAccessEnabled;
 		}
 
 		@Override
@@ -1132,6 +1149,11 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	@Override
 	public boolean isJpaBootstrap() {
 		return options.isJpaBootstrap();
+	}
+
+	@Override
+	public boolean isJtaTransactionAccessEnabled() {
+		return options.isJtaTransactionAccessEnabled();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsImpl.java
@@ -51,6 +51,7 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 	// Session behavior
 	private final boolean flushBeforeCompletionEnabled;
 	private final boolean autoCloseSessionEnabled;
+	private boolean jtaTransactionAccessEnabled;
 
 	// transaction handling
 	private final boolean jtaTrackByThread;
@@ -124,6 +125,7 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 		this.validatorFactoryReference = state.getValidatorFactoryReference();
 
 		this.jpaBootstrap = state.isJpaBootstrap();
+		this.jtaTransactionAccessEnabled = state.isJtaTransactionAccessEnabled();
 		this.sessionFactoryName = state.getSessionFactoryName();
 		this.sessionFactoryNameAlsoJndiName = state.isSessionFactoryNameAlsoJndiName();
 
@@ -195,6 +197,11 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 	@Override
 	public boolean isJpaBootstrap() {
 		return jpaBootstrap;
+	}
+
+	@Override
+	public boolean isJtaTransactionAccessEnabled() {
+		return jtaTransactionAccessEnabled;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
@@ -46,6 +46,8 @@ public interface SessionFactoryOptionsState {
 	@Deprecated
 	boolean isJpaBootstrap();
 
+	boolean isJtaTransactionAccessEnabled();
+
 	Object getBeanManagerReference();
 
 	Object getValidatorFactoryReference();

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -54,6 +54,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
+	public boolean isJtaTransactionAccessEnabled() {
+		return delegate.isJtaTransactionAccessEnabled();
+	}
+
+	@Override
 	public Object getBeanManagerReference() {
 		return delegate.getBeanManagerReference();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderImplementor.java
@@ -28,6 +28,8 @@ public interface SessionFactoryBuilderImplementor extends SessionFactoryBuilder 
 	@Deprecated
 	void markAsJpaBootstrap();
 
+	void disableJtaTransactionAccess();
+
 	/**
 	 * Build the SessionFactoryOptions that will ultimately be passed to SessionFactoryImpl constructor.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -58,6 +58,8 @@ public interface SessionFactoryOptions {
 	@Deprecated
 	boolean isJpaBootstrap();
 
+	boolean isJtaTransactionAccessEnabled();
+
 	/**
 	 * The name to be used for the SessionFactory.  This is use both in:<ul>
 	 *     <li>in-VM serialization</li>

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -1463,4 +1463,15 @@ public interface AvailableSettings {
 	 * @since 5.1
 	 */
 	String CREATE_EMPTY_COMPOSITES_ENABLED = "hibernate.create_empty_composites.enabled";
+
+	/**
+	 * Setting that allows access to the underlying {@link org.hibernate.Transaction}, even
+	 * when using a JTA since normal JPA operations prohibit this behavior.
+	 * <p/>
+	 * Values are {@code true} grants access, {@code false} does not.
+	 * <p/>
+	 * The default behavior is to allow access unless the session is bootstrapped via JPA.
+	 */
+	String ALLOW_JTA_TRANSACTION_ACCESS = "hibernate.jta.allowTransactionAccess";
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -434,6 +434,11 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
+	public Transaction accessTransaction() {
+		return delegate.accessTransaction();
+	}
+
+	@Override
 	public Transaction beginTransaction() {
 		return delegate.beginTransaction();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -21,6 +21,7 @@ import org.hibernate.Interceptor;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.SharedSessionContract;
+import org.hibernate.Transaction;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
@@ -149,6 +150,15 @@ public interface SharedSessionContractImplementor
 	 * or is there a JTA transaction in progress?
 	 */
 	boolean isTransactionInProgress();
+
+	/**
+	 * Provides access to the underlying transaction or creates a new transaction if
+	 * one does not already exist or is active.  This is primarily for internal or
+	 * integrator use.
+	 *
+	 * @return the transaction
+     */
+	Transaction accessTransaction();
 
 	/**
 	 * Hide the changing requirements of entity key creation

--- a/hibernate-core/src/main/java/org/hibernate/jpa/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/AvailableSettings.java
@@ -346,4 +346,14 @@ public interface AvailableSettings {
 	 * @since 5.0.8
 	 */
 	String DELAY_CDI_ACCESS = "hibernate.delay_cdi_access";
+
+	/**
+	 * Setting that allows access to the underlying {@link org.hibernate.Transaction}, even
+	 * when using a JTA since normal JPA operations prohibit this behavior.
+	 * <p/>
+	 * Values are {@code true} grants access, {@code false} does not.
+	 * <p/>
+	 * The default behavior is to allow access unless the session is bootstrapped via JPA.
+	 */
+	String ALLOW_JTA_TRANSACTION_ACCESS = "hibernate.jta.allowTransactionAccess";
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -881,6 +881,12 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 //			sfBuilder.applyInterceptor( sessionFactoryInterceptor );
 //		}
 
+		// will use user override value or default to false if not supplied to follow JPA spec.
+		final boolean jtaTransactionAccessEnabled = readBooleanConfigurationValue( AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS );
+		if ( !jtaTransactionAccessEnabled ) {
+			( ( SessionFactoryBuilderImplementor ) sfBuilder ).disableJtaTransactionAccess();
+		}
+
 		// Locate and apply any requested SessionFactoryObserver
 		final Object sessionFactoryObserverSetting = configurationValues.remove( AvailableSettings.SESSION_FACTORY_OBSERVER );
 		if ( sessionFactoryObserverSetting != null ) {


### PR DESCRIPTION
…
- Add new configuration setting ALLOW_JTA_TRANSACTION_ACCESS.  Uses can use this setting to
override default JPA behavior for transaction access if needed.
- Added new SPI method accessTransaction() which bypasses checks and returns the current or new transaction.