### PR TITLE
HHH-6210 - Envers configuration support for long-based revision end timestamps.

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
@@ -83,6 +83,8 @@ It is possible to configure various aspects of Hibernate Envers behavior, such a
 |`org.hibernate.envers.audit_strategy_validity_revend_timestamp_field_name`|`REVEND_TSTMP` |Column name of the timestamp of the end revision until which the data was valid.
   Only used if the 1ValidityAuditStrategy1 is used, and `org.hibernate.envers.audit_strategy_validity_store_revend_timestamp` evaluates to true
 
+|`org.hibernate.envers.use_numeric_revend_timestamp_type` |`false` |When enabled, uses `Long` data type to represent the revision end timestamp value rather than `Timestamp`.
+
 |`org.hibernate.envers.use_revision_entity_with_native_id` |`true` | Boolean flag that determines the strategy of revision number generation.
   Default implementation of revision entity uses native identifier generator.
   If current database engine does not support identity columns, users are advised to set this property to false.
@@ -117,6 +119,7 @@ be regarded as experimental:
 .  `org.hibernate.envers.track_entities_changed_in_revision`
 .  `org.hibernate.envers.using_modified_flag`
 .  `org.hibernate.envers.modified_flag_suffix`
+.  `org.hibernate.envers.use_numeric_revend_timestamp_type`
 ====
 
 === Additional mapping annotations
@@ -964,6 +967,8 @@ Optionally, you can also override the default values using following properties:
 `org.hibernate.envers.audit_strategy_validity_end_rev_field_name`
 
 `org.hibernate.envers.audit_strategy_validity_revend_timestamp_field_name`
+
+`org.hibernate.envers.use_numeric_revend_timestamp_field_type`
 
 For more information, see <<envers-configuration>>.
 ====

--- a/hibernate-core/src/main/java/org/hibernate/envers/boot/internal/AuditMetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/envers/boot/internal/AuditMetadataBuilderImpl.java
@@ -151,6 +151,7 @@ public class AuditMetadataBuilderImpl implements AuditMetadataBuilderImplementor
 		private final String revisionEndFieldName;
 		private final String revisionEndTimestampFieldName;
 		private final boolean revisionEndTimestampEnabled;
+		private final boolean numericRevisionEndTimestampEnabled;
 		private final String embeddableSetOrdinalPropertyName;
 
 		private boolean trackEntitiesChangedInRevision;
@@ -292,6 +293,17 @@ public class AuditMetadataBuilderImpl implements AuditMetadataBuilderImplementor
 					false
 			);
 
+			if ( this.revisionEndTimestampEnabled ) {
+				this.numericRevisionEndTimestampEnabled = ConfigurationHelper.getBoolean(
+						EnversSettings.USE_NUMERIC_REVEND_TIMESTAMP_FIELD_TYPE,
+						properties,
+						false
+				);
+			}
+			else {
+				this.numericRevisionEndTimestampEnabled = false;
+			}
+
 			this.embeddableSetOrdinalPropertyName = ConfigurationHelper.getString(
 					EnversSettings.EMBEDDABLE_SET_ORDINAL_FIELD_NAME,
 					properties,
@@ -417,6 +429,11 @@ public class AuditMetadataBuilderImpl implements AuditMetadataBuilderImplementor
 		@Override
 		public String getRevisionEndTimestampFieldName() {
 			return revisionEndTimestampFieldName;
+		}
+
+		@Override
+		public boolean isNumericRevisionEndTimestampEnabled() {
+			return numericRevisionEndTimestampEnabled;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/envers/boot/spi/AuditServiceOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/envers/boot/spi/AuditServiceOptions.java
@@ -53,6 +53,8 @@ public interface AuditServiceOptions {
 
 	String getRevisionEndTimestampFieldName();
 
+	boolean isNumericRevisionEndTimestampEnabled();
+
 	String getRevisionNumberPath();
 
 	String getRevisionTypePropName();

--- a/hibernate-core/src/main/java/org/hibernate/envers/configuration/EnversSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/envers/configuration/EnversSettings.java
@@ -122,4 +122,15 @@ public interface EnversSettings {
 	 * Defaults to {@code false}.
 	 */
 	String CASCADE_DELETE_REVISION = "org.hibernate.envers.cascade_delete_revision";
+
+	/**
+	 * When the {@link #AUDIT_STRATEGY_VALIDITY_STORE_REVEND_TIMESTAMP} is {@code true}, the validity audit strategy
+	 * will store the revision end timestamp in each audit table.
+	 *
+	 * The default data type of this field is {@code timestamp}.  There may be situations where the default is not
+	 * desirable and the use of a {@code long} makes sense.  Enabling this will use a {@code long} data type instead.
+	 *
+	 * Defaults to {@code false}.
+	 */
+	String USE_NUMERIC_REVEND_TIMESTAMP_FIELD_TYPE = "org.hibernate.envers.use_numeric_revend_timestamp_field_type";
 }

--- a/hibernate-core/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
@@ -43,6 +43,7 @@ import org.hibernate.tuple.GenerationTiming;
 import org.hibernate.tuple.ValueGeneration;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.ComponentType;
+import org.hibernate.type.LongType;
 import org.hibernate.type.ManyToOneType;
 import org.hibernate.type.OneToOneType;
 import org.hibernate.type.TimestampType;
@@ -181,7 +182,9 @@ public final class AuditMetadataGenerator {
 
 			if ( options.isRevisionEndTimestampEnabled() ) {
 				// add a column for the timestamp of the end revision
-				final String revisionInfoTimestampSqlType = TimestampType.INSTANCE.getName();
+				final String revisionInfoTimestampSqlType = options.isNumericRevisionEndTimestampEnabled()
+						? LongType.INSTANCE.getName()
+						: TimestampType.INSTANCE.getName();
 				final Element timestampProperty = MetadataTools.addProperty(
 						anyMapping,
 						options.getRevisionEndTimestampFieldName(),

--- a/hibernate-core/src/main/java/org/hibernate/envers/strategy/ValidityAuditStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/envers/strategy/ValidityAuditStrategy.java
@@ -286,11 +286,11 @@ public class ValidityAuditStrategy implements AuditStrategy {
 			if ( options.isRevisionEndTimestampEnabled() ) {
 				// Determine the value of the revision property annotated with @RevisionTimestamp
 				String revEndTimestampFieldName = options.getRevisionEndTimestampFieldName();
-				Object revEndTimestampObj = this.revisionTimestampGetter.get( revision );
-				Date revisionEndTimestamp = convertRevEndTimestampToDate( revEndTimestampObj );
-
 				// Setting the end revision timestamp
-				( (Map<String, Object>) previousData ).put( revEndTimestampFieldName, revisionEndTimestamp );
+				( (Map<String, Object>) previousData ).put(
+						revEndTimestampFieldName,
+						getRevisionEndTimestampValue( revision, options )
+				);
 			}
 
 			// Saving the previous version
@@ -302,12 +302,22 @@ public class ValidityAuditStrategy implements AuditStrategy {
 		}
 	}
 
-	private Date convertRevEndTimestampToDate(Object revEndTimestampObj) {
-		// convert to a java.util.Date
-		if ( revEndTimestampObj instanceof Date ) {
-			return (Date) revEndTimestampObj;
+	private Object getRevisionEndTimestampValue(Object revision, AuditServiceOptions options) {
+		Object value = this.revisionTimestampGetter.get( revision );
+		if ( options.isNumericRevisionEndTimestampEnabled() ) {
+			if ( Date.class.isInstance( value ) ) {
+				return ( (Date) value ).getTime();
+			}
+			return value;
 		}
-		return new Date( (Long) revEndTimestampObj );
+		else {
+			if ( Date.class.isInstance( value ) ) {
+				return value;
+			}
+			else {
+				return new Date( (long) value );
+			}
+		}
 	}
 
 	/**
@@ -393,9 +403,8 @@ public class ValidityAuditStrategy implements AuditStrategy {
 		// [, REVEND_TSTMP = ?]
 		if ( options.isRevisionEndTimestampEnabled() ) {
 			final Type timestampType = rootAuditedEntityQueryable.getPropertyType( options.getRevisionEndTimestampFieldName() );
-			final Date timestampValue = convertRevEndTimestampToDate( revisionTimestampGetter.get( revision ) );
 			update.addColumn( rootAuditedEntityQueryable.toColumns( options.getRevisionEndTimestampFieldName() )[0] );
-			update.bind( timestampValue, timestampType );
+			update.bind( getRevisionEndTimestampValue( revision, options ), timestampType );
 		}
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/test/java/org/hibernate/envers/test/integration/strategy/RevisionEndNumericTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/envers/test/integration/strategy/RevisionEndNumericTypeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.strategy;
+
+import java.util.Map;
+
+import org.hibernate.envers.configuration.EnversSettings;
+import org.hibernate.envers.strategy.ValidityAuditStrategy;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.RequiresAuditStrategy;
+import org.hibernate.envers.test.entities.StrTestEntity;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.type.LongType;
+import org.junit.Test;
+
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Validates that when setting the {@link EnversSettings#USE_NUMERIC_REVEND_TIMESTAMP_FIELD_TYPE} is enabled
+ * that the metadata reflects the field type is {@link LongType}.
+ *
+ * @author Chris Cranford
+ */
+@TestForIssue( jiraKey = "HHH-6210" )
+@RequiresAuditStrategy(value = ValidityAuditStrategy.class, jiraKey = "HHH-6210")
+public class RevisionEndNumericTypeTest extends BaseEnversJPAFunctionalTestCase {
+	@Override
+	protected void addConfigOptions(Map options) {
+		super.addConfigOptions( options );
+		options.put( EnversSettings.AUDIT_STRATEGY_VALIDITY_STORE_REVEND_TIMESTAMP, "true" );
+		options.put( EnversSettings.USE_NUMERIC_REVEND_TIMESTAMP_FIELD_TYPE, "true" );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { StrTestEntity.class };
+	}
+
+	@Test
+	public void testRevisionEndTimestampIsLongType() {
+		// get the entity and verify the revision end timestamp property exists
+		final PersistentClass clazz = metadata().getEntityBinding( StrTestEntity.class.getName() + "_AUD" );
+		assertTrue( clazz.hasProperty( getAuditServiceOptions().getRevisionEndTimestampFieldName() ) );
+		// get the revision end timestamp property and confirm it is of Long type.
+		final Property property = clazz.getProperty( getAuditServiceOptions().getRevisionEndTimestampFieldName() );
+		assertTyping( LongType.class, property.getType() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/envers/test/integration/strategy/RevisionEndTimestampTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/envers/test/integration/strategy/RevisionEndTimestampTypeTest.java
@@ -43,11 +43,11 @@ public class RevisionEndTimestampTypeTest extends BaseEnversJPAFunctionalTestCas
 	}
 
 	@Test
-	public void testRevisionEndTimestampIsLongType() {
+	public void testRevisionEndTimestampIsTimestampType() {
 		// get the entity and verify the revision end timestamp property exists
 		final PersistentClass clazz = metadata().getEntityBinding( StrTestEntity.class.getName() + "_AUD" );
 		assertTrue( clazz.hasProperty( getAuditServiceOptions().getRevisionEndTimestampFieldName() ) );
-		// get the revision end timestamp property and confirm it is of Long type.
+		// get the revision end timestamp property and confirm it is of Timestamp type.
 		final Property property = clazz.getProperty( getAuditServiceOptions().getRevisionEndTimestampFieldName() );
 		assertTyping( TimestampType.class, property.getType() );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/envers/test/integration/strategy/RevisionEndTimestampTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/envers/test/integration/strategy/RevisionEndTimestampTypeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.strategy;
+
+import java.util.Map;
+
+import org.hibernate.envers.configuration.EnversSettings;
+import org.hibernate.envers.strategy.ValidityAuditStrategy;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.RequiresAuditStrategy;
+import org.hibernate.envers.test.entities.StrTestEntity;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.type.TimestampType;
+import org.junit.Test;
+
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Validates that when setting the {@link EnversSettings#USE_NUMERIC_REVEND_TIMESTAMP_FIELD_TYPE} is disabled
+ * that the metadata reflects the field type is {@link TimestampType}.
+ *
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-6210")
+@RequiresAuditStrategy(value = ValidityAuditStrategy.class, jiraKey = "HHH-6210")
+public class RevisionEndTimestampTypeTest extends BaseEnversJPAFunctionalTestCase {
+	@Override
+	protected void addConfigOptions(Map options) {
+		super.addConfigOptions( options );
+		options.put( EnversSettings.AUDIT_STRATEGY_VALIDITY_STORE_REVEND_TIMESTAMP, "true" );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { StrTestEntity.class };
+	}
+
+	@Test
+	public void testRevisionEndTimestampIsLongType() {
+		// get the entity and verify the revision end timestamp property exists
+		final PersistentClass clazz = metadata().getEntityBinding( StrTestEntity.class.getName() + "_AUD" );
+		assertTrue( clazz.hasProperty( getAuditServiceOptions().getRevisionEndTimestampFieldName() ) );
+		// get the revision end timestamp property and confirm it is of Long type.
+		final Property property = clazz.getProperty( getAuditServiceOptions().getRevisionEndTimestampFieldName() );
+		assertTyping( TimestampType.class, property.getType() );
+	}
+}


### PR DESCRIPTION
Add new configuration option allowing revision end timestamp fields to be long data-type.