### PR TITLE
Compiler Fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -724,9 +724,9 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		//		1) collection key
 		//		2) collection owner key
 		// these 2 are not always the same.  Same is true in the case of ToOne associations with property-ref...
-		final EntityDescriptor ownerPersister = collectionPersister.getOwnerEntityPersister();
+		final EntityDescriptor ownerPersister = collectionPersister.getOwnerEntityDescriptor();
 		if ( ownerPersister.getIdentifierType().getJavaTypeDescriptor().getJavaType().isInstance( key ) ) {
-			return getEntity( session.generateEntityKey( key, collectionPersister.getOwnerEntityPersister() ) );
+			return getEntity( session.generateEntityKey( key, collectionPersister.getOwnerEntityDescriptor() ) );
 		}
 
 		// we have a property-ref type mapping for the collection key.  But that could show up a few ways here...
@@ -778,7 +778,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		// as a last resort this is what the old code did...
-		return getEntity( session.generateEntityKey( key, collectionPersister.getOwnerEntityPersister() ) );
+		return getEntity( session.generateEntityKey( key, collectionPersister.getOwnerEntityDescriptor() ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
@@ -304,7 +304,7 @@ public class CollectionLoadContext {
 				if ( lce.getCollection() != null ) {
 					final Object linkedOwner = lce.getCollection().getOwner();
 					if ( linkedOwner != null ) {
-						final Serializable ownerKey = persister.getOwnerEntityPersister().getIdentifier( linkedOwner, session );
+						final Serializable ownerKey = persister.getOwnerEntityDescriptor().getIdentifier( linkedOwner, session );
 						collectionOwner = getLoadContext().getPersistenceContext().getCollectionOwner( ownerKey, persister );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/ReattachVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/ReattachVisitor.java
@@ -102,7 +102,7 @@ public abstract class ReattachVisitor extends ProxyVisitor {
 		if ( collectionDescriptor.getCollectionType().useLHSPrimaryKey() ) {
 			return ownerIdentifier;
 		}
-		return (Serializable) collectionDescriptor.getOwnerEntityPersister().getPropertyValue(
+		return (Serializable) collectionDescriptor.getOwnerEntityDescriptor().getPropertyValue(
 				owner,
 				collectionDescriptor.getCollectionType().getLHSPropertyName()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractCollectionEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractCollectionEvent.java
@@ -72,7 +72,7 @@ public abstract class AbstractCollectionEvent extends AbstractEvent {
 		// collectionPersister should not be null, but we don't want to throw
 		// an exception if it is null
 		String entityName =
-				( collectionPersister == null ? null : collectionPersister.getOwnerEntityPersister().getEntityName() );
+				( collectionPersister == null ? null : collectionPersister.getOwnerEntityDescriptor().getEntityName() );
 		if ( affectedOwner != null ) {
 			EntityEntry ee = source.getPersistenceContext().getEntry( affectedOwner );
 			if ( ee != null && ee.getEntityName() != null) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/spi/AbstractPersistentCollectionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/spi/AbstractPersistentCollectionDescriptor.java
@@ -78,7 +78,7 @@ public abstract class AbstractPersistentCollectionDescriptor<O,C,E> implements P
 	//				.. add "structured data" to the cache.
 	private final CacheEntryStructure cacheEntryStructure;
 
-
+	private EntityDescriptor ownerEntityDescriptor;
 	private CollectionIdentifier idDescriptor;
 	private CollectionElement elementDescriptor;
 	private CollectionIndex indexDescriptor;
@@ -165,8 +165,17 @@ public abstract class AbstractPersistentCollectionDescriptor<O,C,E> implements P
 			idDescriptor = null;
 		}
 
+		this.ownerEntityDescriptor = sessionFactory.getTypeConfiguration().findEntityDescriptor(
+				collectionBinding.getOwnerEntityName()
+		);
+
 		this.indexDescriptor = resolveIndexDescriptor( this, collectionBinding, creationContext );
 		this.elementDescriptor = resolveElementDescriptor( this, collectionBinding, separateCollectionTable, creationContext );
+	}
+
+	@Override
+	public EntityDescriptor getOwnerEntityDescriptor() {
+		return this.ownerEntityDescriptor;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/spi/PersistentCollectionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/spi/PersistentCollectionDescriptor.java
@@ -226,6 +226,11 @@ public interface PersistentCollectionDescriptor<O,C,E>
 
 	JavaTypeDescriptor getKeyJavaTypeDescriptor();
 
+	/**
+	 * Get the owning entity descriptor associated with the collection.
+	 */
+	EntityDescriptor getOwnerEntityDescriptor();
+
 	// consider whether we want to keep any of this legacy stuff
 
 //	/**

--- a/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
@@ -253,8 +253,8 @@ public final class MessageHelper {
 			s.append( collectionDescriptor.getNavigableRole().getFullPath() );
 			s.append( '#' );
 			
-			JavaTypeDescriptor ownerIdentifierJavaTypeDescriptor = collectionDescriptor.getOwnerEntityPersister()
-					.getIdentifierType();
+			final JavaTypeDescriptor ownerIdentifierJavaTypeDescriptor = collectionDescriptor.getOwnerEntityDescriptor()
+					.getIdentifierDescriptor().getJavaTypeDescriptor();
 			Serializable ownerKey;
 			// TODO: Is it redundant to attempt to use the collectionKey,
 			// or is always using the owner id sufficient?
@@ -352,9 +352,9 @@ public final class MessageHelper {
 		// Also need to check that the expected identifier type matches
 		// the given ID.  Due to property-ref keys, the collection key
 		// may not be the owner key.
-		JavaTypeDescriptor ownerIdentifierJavaTypeDescriptor = collectionDescriptor.getOwnerEntityPersister()
-				.getIdentifierType();
-		if ( id.getClass().isAssignableFrom( 
+		final JavaTypeDescriptor ownerIdentifierJavaTypeDescriptor = collectionDescriptor.getOwnerEntityDescriptor()
+				.getIdentifierDescriptor().getJavaTypeDescriptor();
+		if ( id.getClass().isAssignableFrom(
 				ownerIdentifierJavaTypeDescriptor.getJavaType() ) ) {
 			s.append( ownerIdentifierJavaTypeDescriptor.extractLoggableRepresentation( id ) );
 		}


### PR DESCRIPTION
Andrea and I are not sure if this change is necessary and wanted your input.

It is our understanding that `#getContainer()` may return a managed type other than `EntityDescriptor`.  There are cases where we have the `PersistentCollectionDescriptor` and we need to obtain some information from the owning entity and rather than having to traverse the runtime model, we decided to expose a `#getOwnerEntityDescriptor()` which we resolve during the finalization of the run-time model.

Is our interpretation of `#getContainer()` accurate or would that always return the root entity in this case?