### PR TITLE
Wip/6.0 schema migration

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
@@ -420,12 +420,12 @@ public interface MetadataBuilder {
 	 *
 	 * @return The unwrapped builder.
 	 */
-	public <T extends MetadataBuilder> T unwrap(Class<T> type);
+	<T extends MetadataBuilder> T unwrap(Class<T> type);
 
 	/**
 	 * Actually build the metamodel
 	 *
 	 * @return The built metadata.
 	 */
-	public Metadata build();
+	Metadata build();
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -1782,7 +1782,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 				Column column = columns[i];
 				String order = orderings != null ? orderings[i] : null;
 				if ( table.containsColumn( column ) ) {
-					uk.addColumn( column, order );
+					uk.addColumn( table.getColumn( column ), order );
 					unbound.remove( column );
 				}
 			}
@@ -1822,7 +1822,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 				Column column = columns[i];
 				String order = orderings != null ? orderings[i] : null;
 				if ( table.containsColumn( column ) ) {
-					index.addColumn( column, order );
+					index.addColumn( table.getColumn( column ), order );
 					unbound.remove( column );
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
@@ -811,7 +811,6 @@ public class BasicValueBinder<T> {
 
 	private class BasicTypeResolverCollectionElementImpl
 			extends BasicTypeResolverConvertibleSupport {
-		private final XProperty attributeDescriptor;
 		private final boolean isLob;
 		private final boolean isNationalized;
 
@@ -824,7 +823,6 @@ public class BasicValueBinder<T> {
 				boolean isNationalized) {
 			super( buildingContext, converterDescriptor );
 
-			this.attributeDescriptor = attributeDescriptor;
 			this.isLob = isLob;
 			this.isNationalized = isNationalized;
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
@@ -250,6 +250,7 @@ public class BasicValueBinder<T> {
 							buildingContext,
 							this.converterDescriptor,
 							navigableXProperty,
+							navigableXClass,
 							isLob,
 							isNationalized
 					);
@@ -818,6 +819,7 @@ public class BasicValueBinder<T> {
 				MetadataBuildingContext buildingContext,
 				AttributeConverterDescriptor converterDescriptor,
 				XProperty attributeDescriptor,
+				XClass elementJavaType,
 				boolean isLob,
 				boolean isNationalized) {
 			super( buildingContext, converterDescriptor );
@@ -828,7 +830,7 @@ public class BasicValueBinder<T> {
 
 			final Class javaType = buildingContext.getBootstrapContext()
 					.getReflectionManager()
-					.toClass( attributeDescriptor.getType() );
+					.toClass( elementJavaType );
 			javaDescriptor = (BasicJavaDescriptor) buildingContext.getBootstrapContext()
 					.getTypeConfiguration()
 					.getJavaTypeDescriptorRegistry()

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL92Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL92Dialect.java
@@ -22,4 +22,9 @@ public class PostgreSQL92Dialect extends PostgreSQL91Dialect {
 		super();
 		this.registerColumnType( Types.JAVA_OBJECT, "json" );
 	}
+
+	@Override
+	public boolean supportsIfExistsAfterAlterTable() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TypeNames.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TypeNames.java
@@ -84,7 +84,7 @@ public class TypeNames {
 	 *
 	 * @throws MappingException Indicates that no registrations were made for that typeCode
 	 */
-	public String get(int typeCode, long size, int precision, int scale) throws MappingException {
+	public String get(int typeCode, Long size, Integer precision, Integer scale) throws MappingException {
 		final Map<Long, String> map = weighted.get( typeCode );
 		if ( map != null && map.size() > 0 ) {
 			// iterate entries ordered by capacity to find first fit
@@ -101,10 +101,17 @@ public class TypeNames {
 		return replace( get( typeCode ), size, precision, scale );
 	}
 
-	private static String replace(String type, long size, int precision, int scale) {
-		type = StringHelper.replaceOnce( type, "$s", Integer.toString( scale ) );
-		type = StringHelper.replaceOnce( type, "$l", Long.toString( size ) );
-		return StringHelper.replaceOnce( type, "$p", Integer.toString( precision ) );
+	private static String replace(String type, Long size, Integer precision, Integer scale) {
+		if ( scale != null ) {
+			type = StringHelper.replaceOnce( type, "$s", Integer.toString( scale ) );
+		}
+		if ( size != null ) {
+			type = StringHelper.replaceOnce( type, "$l", Long.toString( size ) );
+		}
+		if ( precision != null ) {
+			type = StringHelper.replaceOnce( type, "$p", Integer.toString( precision ) );
+		}
+		return type;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -75,7 +75,7 @@ public class BasicValue extends SimpleValue implements BasicValueMapping {
 	@Override
 	public void addColumn(Column column) {
 		if ( getMappedColumns().size() > 0 ) {
-			throw new MappingException( "Attempt to add additional MappedColumn to BasicValueMapping" );
+			throw new MappingException( "Attempt to add additional MappedColumn to BasicValueMapping " + column.getName() );
 		}
 		super.addColumn( column );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/DependantValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DependantValue.java
@@ -8,6 +8,7 @@ package org.hibernate.mapping;
 
 import org.hibernate.boot.model.relational.MappedTable;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.sql.spi.SqlTypeDescriptor;
 
 /**
@@ -30,6 +31,11 @@ public class DependantValue extends BasicValue {
 	@Override
 	protected void setSqlTypeDescriptorResolver(Column column) {
 		column.setSqlTypeDescriptorResolver( new DependantValueSqlTypeDescriptorResolver( columns.size() - 1 ) );
+	}
+
+	@Override
+	public JavaTypeDescriptor getJavaTypeDescriptor() {
+		return wrappedValue.getJavaTypeDescriptor();
 	}
 
 	public class DependantValueSqlTypeDescriptorResolver implements SqlTypeDescriptorResolver {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -104,6 +104,7 @@ public abstract class SimpleValue implements KeyValue {
 			column.setTableName( getTable().getNameIdentifier() );
 		}
 		setSqlTypeDescriptorResolver(column);
+		column.setSimpleValue( this );
 	}
 
 	protected abstract void setSqlTypeDescriptorResolver(Column column);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/PhysicalColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/PhysicalColumn.java
@@ -124,7 +124,11 @@ public class PhysicalColumn implements Column {
 
 	public String getSqlTypeName(Dialect dialect) {
 		if ( sqlType == null ) {
-			sqlType = dialect.getTypeName( getSqlTypeDescriptor().getJdbcTypeCode(), getSize() );
+			Size size = getSize();
+			if ( size.getLength() == null ) {
+				size = dialect.getDefaultSizeStrategy().resolveDefaultSize( getSqlTypeDescriptor(), null );
+			}
+			sqlType = dialect.getTypeName( getSqlTypeDescriptor().getJdbcTypeCode(), size );
 		}
 		return sqlType;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/PhysicalColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/PhysicalColumn.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.metamodel.model.relational.spi;
 
-import org.hibernate.dialect.Dialect;
 import org.hibernate.naming.Identifier;
 import org.hibernate.type.descriptor.sql.spi.SqlTypeDescriptor;
 
@@ -122,14 +121,7 @@ public class PhysicalColumn implements Column {
 		this.checkConstraint = checkConstraint;
 	}
 
-	public String getSqlTypeName(Dialect dialect) {
-		if ( sqlType == null ) {
-			Size size = getSize();
-			if ( size.getLength() == null ) {
-				size = dialect.getDefaultSizeStrategy().resolveDefaultSize( getSqlTypeDescriptor(), null );
-			}
-			sqlType = dialect.getTypeName( getSqlTypeDescriptor().getJdbcTypeCode(), size );
-		}
+	public String getSqlTypeName() {
 		return sqlType;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/consume/multitable/spi/idtable/IdTableExporterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/consume/multitable/spi/idtable/IdTableExporterImpl.java
@@ -47,7 +47,7 @@ public class IdTableExporterImpl implements Exporter<IdTable> {
 			}
 
 			buffer.append( column.getName().render( dialect ) ).append( ' ' );
-			buffer.append( column.getSqlTypeName( dialect ) );
+			buffer.append( column.getSqlTypeName() );
 			// id values cannot be null
 			buffer.append( " not null" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.hibernate.cfg.NotYetImplementedException;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
@@ -294,20 +293,13 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 			Formatter formatter,
 			ExecutionOptions options,
 			GenerationTarget... targets) {
-		// todo: (6.0) create and use a StandardTableAlter
-		throw new NotYetImplementedException(  );
-		//noinspection unchecked
-//		applySqlStrings(
-//				false,
-//				table.sqlAlterStrings(
-//						dialect,
-//						metadata,
-//						tableInformation
-//				),
-//				formatter,
-//				options,
-//				targets
-//		);
+		applySqlStrings(
+				false,
+				dialect.getTableAlter().getSqlAlterStrings( table, tableInformation, jdbcServices ),
+				formatter,
+				options,
+				targets
+		);
 	}
 
 	protected void applyIndexes(

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
@@ -145,7 +145,8 @@ public abstract class AbstractSchemaValidator implements SchemaValidator {
 			ExecutionOptions options,
 			Dialect dialect) {
 		boolean typesMatch = column.getSqlTypeDescriptor().getJdbcTypeCode() == columnInformation.getTypeCode()
-				|| column.getSqlTypeName( dialect ).toLowerCase(Locale.ROOT).startsWith( columnInformation.getTypeName().toLowerCase(Locale.ROOT) );
+				|| column.getSqlTypeName().toLowerCase( Locale.ROOT ).startsWith( columnInformation.getTypeName()
+																						  .toLowerCase( Locale.ROOT ) );
 
 		if ( !typesMatch ) {
 			throw new SchemaManagementException(
@@ -156,7 +157,7 @@ public abstract class AbstractSchemaValidator implements SchemaValidator {
 							table.getQualifiedTableName(),
 							columnInformation.getTypeName().toLowerCase( Locale.ROOT ),
 							JdbcTypeNameMapper.getTypeName( columnInformation.getTypeCode() ),
-							column.getSqlTypeName( dialect ).toLowerCase( Locale.ROOT ),
+							column.getSqlTypeName().toLowerCase( Locale.ROOT ),
 							JdbcTypeNameMapper.getTypeName( column.getSqlTypeDescriptor().getJdbcTypeCode() )
 					)
 			);

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableAlter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableAlter.java
@@ -55,7 +55,7 @@ public class StandardTableAlter implements Alter<ExportableTable> {
 						.append( ' ' )
 						.append( physicalColumn.getName().render( dialect ) )
 						.append( ' ' )
-						.append( physicalColumn.getSqlTypeName( dialect ) );
+						.append( physicalColumn.getSqlTypeName() );
 
 				final String defaultValue = physicalColumn.getDefaultValue();
 				if ( defaultValue != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableAlter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableAlter.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.tool.schema.internal;
+
+import java.util.Collection;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.metamodel.model.relational.spi.ExportableTable;
+import org.hibernate.metamodel.model.relational.spi.PhysicalColumn;
+import org.hibernate.naming.spi.QualifiedName;
+import org.hibernate.naming.spi.QualifiedNameParser;
+import org.hibernate.tool.schema.extract.spi.ColumnInformation;
+import org.hibernate.tool.schema.extract.spi.TableInformation;
+import org.hibernate.tool.schema.spi.Alter;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Andrea Boriero
+ */
+public class StandardTableAlter implements Alter<ExportableTable> {
+	private static final Logger log = Logger.getLogger( StandardTableAlter.class );
+
+	protected final Dialect dialect;
+
+	public StandardTableAlter(Dialect dialect) {
+		this.dialect = dialect;
+	}
+
+	@Override
+	public String[] getSqlAlterStrings(ExportableTable table, TableInformation tableInfo, JdbcServices jdbcServices) {
+		final QualifiedName tableName = new QualifiedNameParser.NameParts(
+				table.getCatalogName(),
+				table.getSchemaName(),
+				table.getTableName()
+		);
+
+		final StringBuilder root = new StringBuilder( dialect.getAlterTableString( tableName.render() ) )
+				.append( ' ' )
+				.append( dialect.getAddColumnString() );
+		final Collection<PhysicalColumn> physicalColumns = table.getPhysicalColumns();
+		final String[] results = new String[physicalColumns.size()];
+		int i = 0;
+		for ( PhysicalColumn physicalColumn : physicalColumns ) {
+			final ColumnInformation columnInfo = tableInfo.getColumn( physicalColumn.getName() );
+
+			if ( columnInfo == null ) {
+				// the column doesnt exist at all.
+				StringBuilder alter = new StringBuilder( root.toString() )
+						.append( ' ' )
+						.append( physicalColumn.getName().render( dialect ) )
+						.append( ' ' )
+						.append( physicalColumn.getSqlTypeName( dialect ) );
+
+				final String defaultValue = physicalColumn.getDefaultValue();
+				if ( defaultValue != null ) {
+					alter.append( " default " ).append( defaultValue );
+				}
+
+				if ( physicalColumn.isNullable() ) {
+					alter.append( dialect.getNullColumnString() );
+				}
+				else {
+					alter.append( " not null" );
+				}
+
+				if ( physicalColumn.isUnique() ) {
+					alter.append( dialect.getUniqueDelegate()
+										  .getColumnDefinitionUniquenessFragment( physicalColumn ) );
+				}
+
+				if ( physicalColumn.getCheckConstraint() != null && dialect.supportsColumnCheck() ) {
+					alter.append( " check(" )
+							.append( physicalColumn.getCheckConstraint() )
+							.append( ")" );
+				}
+
+				final String columnComment = physicalColumn.getComment();
+				if ( columnComment != null ) {
+					alter.append( dialect.getColumnComment( columnComment ) );
+				}
+
+				alter.append( dialect.getAddColumnSuffixString() );
+
+				results[i] = alter.toString();
+				i++;
+			}
+		}
+
+		if ( results.length == 0 ) {
+			log.debugf( "No alter strings for table : %s", table.getTableName().render( dialect ) );
+		}
+		return results;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
@@ -225,6 +225,5 @@ public class StandardTableExporter implements Exporter<ExportableTable> {
 
 	protected String tableCreateString(boolean hasPrimaryKey) {
 		return hasPrimaryKey ? dialect.getCreateTableString() : dialect.getCreateMultisetTableString();
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
@@ -86,7 +86,7 @@ public class StandardTableExporter implements Exporter<ExportableTable> {
 										 .getIdentityColumnString( col.getSqlTypeDescriptor().getJdbcTypeCode() ) );
 			}
 			else {
-				buf.append( col.getSqlTypeName( dialect ) );
+				buf.append( col.getSqlTypeName() );
 
 				String defaultValue = col.getDefaultValue();
 				if ( defaultValue != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Alter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Alter.java
@@ -8,6 +8,7 @@ package org.hibernate.tool.schema.spi;
 
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.metamodel.model.relational.spi.Exportable;
+import org.hibernate.tool.schema.extract.spi.TableInformation;
 
 /**
  * Defines a contract for exporting of database objects (tables, etc) for use in SQL {@code ALTER} scripts.
@@ -16,7 +17,7 @@ import org.hibernate.metamodel.model.relational.spi.Exportable;
  *
  * @author Andrea Boriero
  */
-public interface Alterer<T extends Exportable> {
+public interface Alter<T extends Exportable> {
 	String[] NO_COMMANDS = new String[0];
 
 	/**
@@ -24,5 +25,5 @@ public interface Alterer<T extends Exportable> {
 	 *
 	 * @return The commands needed for alter scripting.
 	 */
-	String[] getSqlAlterStrings(T exportable, JdbcServices jdbcServices);
+	String[] getSqlAlterStrings(T exportable, TableInformation tableInfo, JdbcServices jdbcServices);
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Alter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Alter.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.tool.schema.spi;
+
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.metamodel.model.relational.spi.Exportable;
+
+/**
+ * Defines a contract for exporting of database objects (tables, etc) for use in SQL {@code ALTER} scripts.
+ * <p/>
+ * This is an ORM-centric contract
+ *
+ * @author Andrea Boriero
+ */
+public interface Alterer<T extends Exportable> {
+	String[] NO_COMMANDS = new String[0];
+
+	/**
+	 * Get the commands needed for alter.
+	 *
+	 * @return The commands needed for alter scripting.
+	 */
+	String[] getSqlAlterStrings(T exportable, JdbcServices jdbcServices);
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/BaseSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/BaseSchemaTest.java
@@ -1,0 +1,137 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.schemaupdate;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.hbm2ddl.SchemaValidator;
+import org.hibernate.tool.schema.JdbcMetadaAccessStrategy;
+import org.hibernate.tool.schema.TargetType;
+import org.hibernate.tool.schema.internal.Helper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * @author Andrea Boriero
+ */
+@RunWith(Parameterized.class)
+public abstract class BaseSchemaTest {
+	protected static final Class<?>[] NO_CLASSES = new Class[0];
+
+	@Parameterized.Parameters
+	public static Collection<String> parameters() {
+		return Arrays.asList(
+				new String[] {
+						JdbcMetadaAccessStrategy.GROUPED.toString()
+						, JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()
+				}
+		);
+	}
+
+	@Parameterized.Parameter
+	public String jdbcMetadataExtractorStrategy;
+
+	private StandardServiceRegistry standardServiceRegistry;
+	private DatabaseModel databaseModel;
+	private File output;
+
+	@Before
+	public void setUp() throws IOException {
+		standardServiceRegistry = new StandardServiceRegistryBuilder()
+				.applySetting( AvailableSettings.KEYWORD_AUTO_QUOTING_ENABLED, "true" )
+				.applySetting(
+						AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY,
+						jdbcMetadataExtractorStrategy
+				)
+				.build();
+		if ( createTempOutputFile() ) {
+			output = File.createTempFile( "update_script", ".sql" );
+			output.deleteOnExit();
+		}
+		MetadataSources metadataSources = new MetadataSources( standardServiceRegistry );
+		Class<?>[] annotatedClasses = getAnnotatedClasses();
+		for ( int i = 0; i < annotatedClasses.length; i++ ) {
+			metadataSources.addAnnotatedClass( annotatedClasses[i] );
+		}
+		final MetadataImplementor metadata = (MetadataImplementor) metadataSources.buildMetadata();
+		databaseModel = Helper.buildDatabaseModel( metadata );
+		new SchemaExport( databaseModel, standardServiceRegistry ).create( EnumSet.of( TargetType.DATABASE ) );
+	}
+
+	protected Class<?>[] getAnnotatedClasses() {
+		return NO_CLASSES;
+	}
+
+	protected boolean createTempOutputFile() {
+		return false;
+	}
+
+	public StandardServiceRegistry getStandardServiceRegistry() {
+		return standardServiceRegistry;
+	}
+
+	public DatabaseModel getDatabaseModel() {
+		return databaseModel;
+	}
+
+	public SchemaUpdate createSchemaUpdate() {
+		SchemaUpdate schemaUpdate = new SchemaUpdate( databaseModel, standardServiceRegistry );
+		if ( createTempOutputFile() ) {
+			schemaUpdate.setOutputFile( output.getAbsolutePath() );
+		}
+		return schemaUpdate;
+	}
+
+	public SchemaExport createSchemaExport() {
+		SchemaExport schemaExport = new SchemaExport( databaseModel, standardServiceRegistry );
+		if ( createTempOutputFile() ) {
+			schemaExport.setOutputFile( output.getAbsolutePath() );
+		}
+		return schemaExport;
+	}
+
+	public SchemaValidator createSchemaValidator() {
+		return new SchemaValidator( databaseModel, standardServiceRegistry );
+	}
+
+	public String getOutputFileContent() throws IOException {
+		if ( createTempOutputFile() ) {
+			return new String( Files.readAllBytes( output.toPath() ) );
+		}
+		else {
+			throw new RuntimeException(
+					"Temporary Output file was not created, the BaseSchemaTest createTempOutputFile() method must be overridden to return true" );
+		}
+	}
+
+	@After
+	public void tearDown() {
+		try {
+			createSchemaExport().drop( EnumSet.of( TargetType.DATABASE ) );
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( standardServiceRegistry );
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaCreationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaCreationTest.java
@@ -1,0 +1,123 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.schemaupdate;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.JdbcMetadaAccessStrategy;
+import org.hibernate.tool.schema.TargetType;
+import org.hibernate.tool.schema.internal.Helper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@RunWith(Parameterized.class)
+public class SchemaCreationTest {
+
+	@Parameterized.Parameters
+	public static Collection<String> parameters() {
+		return Arrays.asList(
+				new String[] {
+						JdbcMetadaAccessStrategy.GROUPED.toString(),
+						JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()
+				}
+		);
+	}
+
+	@Parameterized.Parameter
+	public String jdbcMetadataExtractorStrategy;
+
+	private StandardServiceRegistry ssr;
+	private DatabaseModel databaseModel;
+	private File output;
+
+	@Before
+	public void setUp() throws IOException {
+		ssr = new StandardServiceRegistryBuilder()
+				.applySetting( AvailableSettings.KEYWORD_AUTO_QUOTING_ENABLED, "true" )
+				.applySetting(
+						AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY,
+						jdbcMetadataExtractorStrategy
+				)
+				.build();
+		output = File.createTempFile( "update_script", ".sql" );
+		output.deleteOnExit();
+
+		final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( ssr )
+				.addAnnotatedClass( Employee.class )
+				.buildMetadata();
+		databaseModel = Helper.buildDatabaseModel( metadata );
+		new SchemaExport( databaseModel, ssr ).create( EnumSet.of( TargetType.DATABASE ) );
+	}
+
+	@After
+	public void tearDown() {
+		try {
+			new SchemaExport( databaseModel, ssr ).drop( EnumSet.of( TargetType.DATABASE ) );
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+
+	@Test
+	public void testSchemaUpdateWithQuotedColumnNames() throws Exception {
+		new SchemaUpdate( databaseModel, ssr )
+				.setOutputFile( output.getAbsolutePath() )
+				.execute(
+						EnumSet.of( TargetType.SCRIPT )
+				);
+
+		final String fileContent = new String( Files.readAllBytes( output.toPath() ) );
+		assertThat( "The update output file should be empty", fileContent, is( "" ) );
+	}
+
+	@Entity
+	@Table(name = "Employee")
+	public class Employee {
+		@Id
+		private long id;
+
+		@Column(name = "`Age`")
+		public String age;
+
+		@Column(name = "Name")
+		private String name;
+
+		private String match;
+
+		private String birthday;
+
+		private String homeAddress;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaCreationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaCreationTest.java
@@ -6,34 +6,15 @@
  */
 package org.hibernate.orm.test.schemaupdate;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.EnumSet;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistry;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.boot.spi.MetadataImplementor;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
-import org.hibernate.tool.hbm2ddl.SchemaExport;
-import org.hibernate.tool.hbm2ddl.SchemaUpdate;
-import org.hibernate.tool.schema.JdbcMetadaAccessStrategy;
 import org.hibernate.tool.schema.TargetType;
-import org.hibernate.tool.schema.internal.Helper;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -41,64 +22,22 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Andrea Boriero
  */
-@RunWith(Parameterized.class)
-public class SchemaCreationTest {
-
-	@Parameterized.Parameters
-	public static Collection<String> parameters() {
-		return Arrays.asList(
-				new String[] {
-						JdbcMetadaAccessStrategy.GROUPED.toString(),
-						JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()
-				}
-		);
+public class SchemaCreationTest extends BaseSchemaTest {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{Employee.class };
 	}
 
-	@Parameterized.Parameter
-	public String jdbcMetadataExtractorStrategy;
-
-	private StandardServiceRegistry ssr;
-	private DatabaseModel databaseModel;
-	private File output;
-
-	@Before
-	public void setUp() throws IOException {
-		ssr = new StandardServiceRegistryBuilder()
-				.applySetting( AvailableSettings.KEYWORD_AUTO_QUOTING_ENABLED, "true" )
-				.applySetting(
-						AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY,
-						jdbcMetadataExtractorStrategy
-				)
-				.build();
-		output = File.createTempFile( "update_script", ".sql" );
-		output.deleteOnExit();
-
-		final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( ssr )
-				.addAnnotatedClass( Employee.class )
-				.buildMetadata();
-		databaseModel = Helper.buildDatabaseModel( metadata );
-		new SchemaExport( databaseModel, ssr ).create( EnumSet.of( TargetType.DATABASE ) );
-	}
-
-	@After
-	public void tearDown() {
-		try {
-			new SchemaExport( databaseModel, ssr ).drop( EnumSet.of( TargetType.DATABASE ) );
-		}
-		finally {
-			StandardServiceRegistryBuilder.destroy( ssr );
-		}
+	@Override
+	protected boolean createTempOutputFile() {
+		return true;
 	}
 
 	@Test
 	public void testSchemaUpdateWithQuotedColumnNames() throws Exception {
-		new SchemaUpdate( databaseModel, ssr )
-				.setOutputFile( output.getAbsolutePath() )
-				.execute(
-						EnumSet.of( TargetType.SCRIPT )
-				);
+		createSchemaUpdate().setHaltOnError( true ).execute( EnumSet.of( TargetType.SCRIPT ) );
 
-		final String fileContent = new String( Files.readAllBytes( output.toPath() ) );
+		final String fileContent = getOutputFileContent();
 		assertThat( "The update output file should be empty", fileContent, is( "" ) );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaUpdateTest.java
@@ -1,0 +1,233 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.schemaupdate;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.Table;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.naming.Identifier;
+import org.hibernate.tool.schema.TargetType;
+
+import org.hibernate.testing.SkipLog;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@RunWith(Parameterized.class)
+public class SchemaUpdateTest extends BaseSchemaTest {
+
+	private boolean skipTest;
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				LowercaseTableNameEntity.class
+				, TestEntity.class
+				, UppercaseTableNameEntity.class
+				, MixedCaseTableNameEntity.class
+				, Match.class
+				, InheritanceRootEntity.class
+				, InheritanceChildEntity.class
+				, InheritanceSecondChildEntity.class
+		};
+	}
+
+	@Override
+	protected boolean createTempOutputFile() {
+		return true;
+	}
+
+	@Override
+	public void setUp() throws IOException {
+		super.setUp();
+		if ( SQLServerDialect.class.isAssignableFrom( Dialect.getDialect().getClass() ) ) {
+			// SQLServerDialect stores case-insensitive quoted identifiers in mixed case,
+			// so the checks at the end of this method won't work.
+			skipTest = true;
+			return;
+		}
+
+		// Databases that use case-insensitive quoted identifiers need to be skipped.
+		// The following checks will work for checking those dialects that store case-insensitive
+		// quoted identifiers as upper-case or lower-case. It does not work for dialects that
+		// store case-insensitive identifiers in mixed case (like SQL Server).
+		final IdentifierHelper identifierHelper = getStandardServiceRegistry().getService( JdbcEnvironment.class )
+				.getIdentifierHelper();
+		final String lowerCaseName = identifierHelper.toMetaDataObjectName( Identifier.toIdentifier(
+				"testentity",
+				true
+		) );
+		final String upperCaseName = identifierHelper.toMetaDataObjectName( Identifier.toIdentifier(
+				"TESTENTITY",
+				true
+		) );
+		final String mixedCaseName = identifierHelper.toMetaDataObjectName( Identifier.toIdentifier(
+				"TESTentity",
+				true
+		) );
+		if ( lowerCaseName.equals( upperCaseName ) ||
+				lowerCaseName.equals( mixedCaseName ) ||
+				upperCaseName.equals( mixedCaseName ) ) {
+			StandardServiceRegistryBuilder.destroy( getStandardServiceRegistry() );
+			skipTest = true;
+		}
+	}
+
+	@Override
+	public void tearDown() {
+		if ( skipTest ) {
+			return;
+		}
+		super.tearDown();
+	}
+
+	@Test
+	public void testSchemaUpdateAndValidation() throws Exception {
+		if ( skipTest ) {
+			SkipLog.reportSkip( "skipping test because quoted names are not case-sensitive." );
+			return;
+		}
+
+		createSchemaUpdate().setHaltOnError( true )
+				.execute( EnumSet.of( TargetType.DATABASE ) );
+
+		createSchemaValidator().validate();
+
+		createSchemaUpdate().setHaltOnError( true )
+				.setFormat( false )
+				.execute( EnumSet.of( TargetType.DATABASE, TargetType.SCRIPT ) );
+
+		final String fileContent = getOutputFileContent();
+		assertThat( "The update output file should be empty", fileContent, is( "" ) );
+	}
+
+	@Entity(name = "TestEntity")
+	@Table(name = "`testentity`")
+	public static class LowercaseTableNameEntity {
+		@Id
+		long id;
+		String field1;
+
+		@ManyToMany(mappedBy = "entities")
+		Set<TestEntity> entity1s;
+	}
+
+	@Entity(name = "TestEntity1")
+	public static class TestEntity {
+		@Id
+		@Column(name = "`Id`")
+		long id;
+		String field1;
+
+		@ManyToMany
+		Set<LowercaseTableNameEntity> entities;
+
+		@OneToMany
+		@JoinColumn
+		private Set<UppercaseTableNameEntity> entitie2s;
+
+		@ManyToOne
+		private LowercaseTableNameEntity entity;
+	}
+
+	@Entity(name = "TestEntity2")
+	@Table(name = "`TESTENTITY`")
+	public static class UppercaseTableNameEntity {
+		@Id
+		long id;
+		String field1;
+
+		@ManyToOne
+		TestEntity testEntity;
+
+		@ManyToOne
+		@JoinColumn(foreignKey = @ForeignKey(name = "FK_mixedCase"))
+		MixedCaseTableNameEntity mixedCaseTableNameEntity;
+	}
+
+	@Entity(name = "TestEntity3")
+	@Table(name = "`TESTentity`", indexes = {
+			@Index(name = "index1", columnList = "`FieLd1`"),
+			@Index(name = "Index2", columnList = "`FIELD_2`")
+	})
+	public static class MixedCaseTableNameEntity {
+		@Id
+		long id;
+		@Column(name = "`FieLd1`")
+		String field1;
+		@Column(name = "`FIELD_2`")
+		String field2;
+		@Column(name = "`field_3`")
+		String field3;
+		String field4;
+
+		@OneToMany
+		@JoinColumn
+		private Set<Match> matches = new HashSet<>();
+	}
+
+	@Entity(name = "Match")
+	public static class Match {
+		@Id
+		long id;
+		String match;
+
+		@ElementCollection
+		@CollectionTable
+		private Map<Integer, Integer> timeline = new TreeMap<>();
+	}
+
+	@Entity(name = "InheritanceRootEntity")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static class InheritanceRootEntity {
+		@Id
+		protected Long id;
+	}
+
+	@Entity(name = "InheritanceChildEntity")
+	@PrimaryKeyJoinColumn(name = "ID", foreignKey = @ForeignKey(name = "FK_ROOT"))
+	public static class InheritanceChildEntity extends InheritanceRootEntity {
+	}
+
+	@Entity(name = "InheritanceSecondChildEntity")
+	@PrimaryKeyJoinColumn(name = "ID")
+	public static class InheritanceSecondChildEntity extends InheritanceRootEntity {
+		@ManyToOne
+		@JoinColumn
+		public Match match;
+	}
+}


### PR DESCRIPTION
The first working test for the schema migration.

Not sure about the name I gave to  the  org.hibernate.tool.schema.spi.Alter`inerface, any suggestion is more than welcome.
Another doubt is related with the implementation and use of  the `DefaultSizeStrategy`.

The `PhysicalColumn` where the `DefaultSizeStrategy#resolveDefaultSize(SqlTypeDescriptor sqlType, JavaTypeDescriptor javaType)` is used at the moment has no concept of the `JavaTypeDescriptor`.

So not sure if in some way we have to pass this information to the `PhysicalColumn` or to just remove the `JavaTypeDescriptor` from the method signature. 