### PR TITLE
Wip/6.0 databasemodel

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
@@ -26,6 +26,7 @@ public interface MetadataBuildingContext {
 	BootstrapContext getBootstrapContext();
 
 	TypeDefinition resolveTypeDefinition(String typeName);
+
 	void addTypeDefinition(TypeDefinition typeDefinition);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -42,6 +42,7 @@ import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.metamodel.model.domain.spi.AllowableParameterType;
 import org.hibernate.metamodel.model.domain.spi.EntityDescriptor;
 import org.hibernate.metamodel.model.domain.spi.PersistentCollectionDescriptor;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.spi.NamedQueryRepository;
@@ -225,6 +226,11 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	@Override
 	public EntityGraph findEntityGraphByName(String name) {
 		return delegate.findEntityGraphByName( name );
+	}
+
+	@Override
+	public void processSchemaManagementToolCoordinator(DataBaseModelExtended dataBaseModel) {
+		delegate.processSchemaManagementToolCoordinator( dataBaseModel );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -35,6 +35,7 @@ import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.internal.util.collections.streams.StreamUtils;
 import org.hibernate.metamodel.model.domain.spi.EntityDescriptor;
 import org.hibernate.metamodel.model.domain.spi.PersistentCollectionDescriptor;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.spi.NamedQueryRepository;
 import org.hibernate.query.spi.QueryEngine;
@@ -427,4 +428,6 @@ public interface SessionFactoryImplementor
 	}
 
 	EntityGraph findEntityGraphByName(String name);
+
+	void processSchemaManagementToolCoordinator(DataBaseModelExtended dataBaseModel);
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java
@@ -19,6 +19,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.model.domain.spi.EmbeddedTypeDescriptor;
 import org.hibernate.metamodel.model.domain.spi.EntityDescriptor;
 import org.hibernate.metamodel.model.domain.spi.MappedSuperclassDescriptor;
+import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.type.descriptor.java.spi.ManagedJavaDescriptor;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -33,6 +34,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 public class MetamodelImpl implements MetamodelImplementor, Serializable {
 	private final SessionFactoryImplementor sessionFactory;
 	private final TypeConfiguration typeConfiguration;
+	private final DatabaseModel databaseModel;
 
 	private final Map<ManagedJavaDescriptor<?>, MappedSuperclassDescriptor<?>> jpaMappedSuperclassTypeMap = new ConcurrentHashMap<>();
 
@@ -41,9 +43,18 @@ public class MetamodelImpl implements MetamodelImplementor, Serializable {
 	 *
 	 * @param typeConfiguration The TypeConfiguration to use for this Metamodel
 	 */
-	public MetamodelImpl(SessionFactoryImplementor sessionFactory, TypeConfiguration typeConfiguration) {
+	public MetamodelImpl(
+			SessionFactoryImplementor sessionFactory,
+			TypeConfiguration typeConfiguration,
+			DatabaseModel databaseModel) {
 		this.sessionFactory = sessionFactory;
 		this.typeConfiguration = typeConfiguration;
+		this.databaseModel = databaseModel;
+	}
+
+	@Override
+	public DatabaseModel getDatabaseModel(){
+		return databaseModel;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/internal/DataBaseModelExtendedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/internal/DataBaseModelExtendedImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.metamodel.model.relational.internal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.boot.model.relational.InitCommand;
+import org.hibernate.metamodel.model.relational.spi.AuxiliaryDatabaseObject;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
+import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+
+/**
+ * @author Andrea Boriero
+ */
+public class DataBaseModelExtendedImpl implements DataBaseModelExtended {
+
+	private final DatabaseModel databaseModel;
+	private final List<AuxiliaryDatabaseObject> auxiliaryDatabaseObjects = new ArrayList<>();
+	private final List<InitCommand> initCommands = new ArrayList<>();
+
+	public DataBaseModelExtendedImpl(DatabaseModel databaseModel) {
+		this.databaseModel = databaseModel;
+	}
+
+	@Override
+	public DatabaseModel getDataBaseModel() {
+		return databaseModel;
+	}
+
+	@Override
+	public Collection<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects() {
+		return auxiliaryDatabaseObjects;
+	}
+
+	@Override
+	public Collection<InitCommand> getInitCommands() {
+		return initCommands;
+	}
+
+	public void addInitCommand(InitCommand initCommand) {
+		initCommands.add( initCommand );
+	}
+
+	public void addAuxiliaryDatabaseObject(AuxiliaryDatabaseObject auxiliaryDatabaseObject) {
+		this.auxiliaryDatabaseObjects.add( auxiliaryDatabaseObject );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/internal/DatabaseModelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/internal/DatabaseModelImpl.java
@@ -9,12 +9,9 @@ package org.hibernate.metamodel.model.relational.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
-import org.hibernate.boot.model.relational.InitCommand;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
-import org.hibernate.metamodel.model.relational.spi.AuxiliaryDatabaseObject;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.metamodel.model.relational.spi.Namespace;
 
@@ -25,9 +22,7 @@ public class DatabaseModelImpl implements DatabaseModel {
 	private final JdbcEnvironment getJdbcEnvironment;
 
 	private Namespace defautlNamespace;
-	private List<AuxiliaryDatabaseObject> auxiliaryDatabaseObjects;
 	private final List<Namespace> namespaces = new ArrayList<>();
-	private List<InitCommand> initCommands = new ArrayList<>();
 
 	public DatabaseModelImpl(JdbcEnvironment getJdbcEnvironment) {
 		this.getJdbcEnvironment = getJdbcEnvironment;
@@ -48,36 +43,11 @@ public class DatabaseModelImpl implements DatabaseModel {
 		return getJdbcEnvironment;
 	}
 
-	@Override
-	public Collection<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects() {
-		if ( auxiliaryDatabaseObjects == null ) {
-			return Collections.emptyList();
-		}
-		return auxiliaryDatabaseObjects;
-	}
-
-	@Override
-	public Collection<InitCommand> getInitCommands() {
-		return initCommands;
-	}
-
-	@Override
-	public void addInitCommand(InitCommand initCommand) {
-		initCommands.add( initCommand );
-	}
-
 	public void addNamespace(Namespace namespace) {
 		namespaces.add( namespace );
 	}
 
 	public void setDefaultNamespace(Namespace namespace){
 		defautlNamespace = namespace;
-	}
-
-	public void addAuxiliaryDatabaseObject(AuxiliaryDatabaseObject auxiliaryDatabaseObject) {
-		if ( auxiliaryDatabaseObjects == null ) {
-			auxiliaryDatabaseObjects = new ArrayList<>();
-		}
-		this.auxiliaryDatabaseObjects.add( auxiliaryDatabaseObject );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/DataBaseModelExtended.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/DataBaseModelExtended.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.metamodel.model.relational.spi;
+
+import java.util.Collection;
+
+import org.hibernate.boot.model.relational.InitCommand;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+/**
+ * @author Andrea Boriero
+ */
+public interface DataBaseModelExtended {
+
+	DatabaseModel getDataBaseModel();
+
+	Collection<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects();
+
+	Collection<InitCommand> getInitCommands();
+
+	default Collection<Namespace> getNamespaces(){
+		return getDataBaseModel().getNamespaces();
+	}
+
+	default Namespace getDefaultNamespace(){
+		return getDataBaseModel().getDefaultNamespace();
+	}
+
+	default JdbcEnvironment getJdbcEnvironment(){
+		return getDataBaseModel().getJdbcEnvironment();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/DatabaseModel.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/DatabaseModel.java
@@ -8,7 +8,6 @@ package org.hibernate.metamodel.model.relational.spi;
 
 import java.util.Collection;
 
-import org.hibernate.boot.model.relational.InitCommand;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 
 /**
@@ -21,10 +20,4 @@ public interface DatabaseModel {
 	Namespace getDefaultNamespace();
 
 	JdbcEnvironment getJdbcEnvironment();
-
-	Collection<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects();
-
-	Collection<InitCommand> getInitCommands();
-
-	void addInitCommand(InitCommand initCommand);
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/MetamodelImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/MetamodelImplementor.java
@@ -15,6 +15,7 @@ import org.hibernate.Metamodel;
 import org.hibernate.internal.util.collections.streams.StreamUtils;
 import org.hibernate.metamodel.model.domain.spi.EntityDescriptor;
 import org.hibernate.metamodel.model.domain.spi.PersistentCollectionDescriptor;
+import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -25,11 +26,8 @@ import org.hibernate.type.spi.TypeConfiguration;
  * accessible via {@link #getTypeConfiguration()}
  */
 public interface MetamodelImplementor extends Metamodel {
-	// todo (6.0) : would be awesome to expose the runtime database model here
-	//		however that has some drawbacks that we need to discuss, namely
-	//		that DatabaseModel holds state that we do not need beyond
-	//		schema-management tooling - init-commands and aux-db-objects
 
+	DatabaseModel getDatabaseModel();
 	/**
 	 * Close the Metamodel
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
@@ -31,7 +31,7 @@ import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.schema.SourceType;
 import org.hibernate.tool.schema.TargetType;
@@ -60,10 +60,10 @@ import org.hibernate.tool.schema.spi.TargetDescriptor;
 public class SchemaExport {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( SchemaExport.class );
 
-	private final DatabaseModel databaseModel;
+	private final DataBaseModelExtended databaseModel;
 	private final ServiceRegistry serviceRegistry;
 
-	public SchemaExport(DatabaseModel databaseModel, ServiceRegistry serviceRegistry) {
+	public SchemaExport(DataBaseModelExtended databaseModel, ServiceRegistry serviceRegistry) {
 		this.databaseModel = databaseModel;
 		this.serviceRegistry = serviceRegistry;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaUpdate.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaUpdate.java
@@ -30,6 +30,7 @@ import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.schema.TargetType;
@@ -51,14 +52,14 @@ public class SchemaUpdate {
 
 	private final List<Exception> exceptions = new ArrayList<>();
 
-	private final DatabaseModel databaseModel;
+	private final DataBaseModelExtended databaseModel;
 	private final ServiceRegistry serviceRegistry;
 
 	private String outputFile;
 	private String delimiter;
 	private boolean format;
 
-	public SchemaUpdate(DatabaseModel databaseModel, ServiceRegistry serviceRegistry) {
+	public SchemaUpdate(DataBaseModelExtended databaseModel, ServiceRegistry serviceRegistry) {
 		this.databaseModel = databaseModel;
 		this.serviceRegistry = serviceRegistry;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaValidator.java
@@ -28,7 +28,7 @@ import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.schema.internal.ExceptionHandlerHaltImpl;
 import org.hibernate.tool.schema.internal.Helper;
@@ -45,10 +45,10 @@ import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator;
 public class SchemaValidator {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( SchemaValidator.class );
 
-	protected final DatabaseModel databaseModel;
+	protected final DataBaseModelExtended databaseModel;
 	protected final ServiceRegistry serviceRegistry;
 
-	public SchemaValidator(DatabaseModel databaseModel, ServiceRegistry serviceRegistry) {
+	public SchemaValidator(DataBaseModelExtended databaseModel, ServiceRegistry serviceRegistry) {
 		this.databaseModel = databaseModel;
 		this.serviceRegistry = serviceRegistry;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -19,6 +19,7 @@ import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.metamodel.model.relational.spi.AuxiliaryDatabaseObject;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.metamodel.model.relational.spi.Exportable;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
@@ -60,12 +61,12 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 
 	protected final HibernateSchemaManagementTool tool;
 	protected final SchemaFilter schemaFilter;
-	protected final DatabaseModel databaseModel;
+	protected final DataBaseModelExtended databaseModel;
 	protected final JdbcServices jdbcServices;
 
 	public AbstractSchemaMigrator(
 			HibernateSchemaManagementTool tool,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaFilter schemaFilter) {
 		this.tool = tool;
 		this.databaseModel = databaseModel;

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
@@ -9,7 +9,7 @@ package org.hibernate.tool.schema.internal;
 import java.util.Locale;
 
 import org.hibernate.dialect.Dialect;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
 import org.hibernate.metamodel.model.relational.spi.Namespace;
 import org.hibernate.metamodel.model.relational.spi.PhysicalColumn;
@@ -35,12 +35,12 @@ public abstract class AbstractSchemaValidator implements SchemaValidator {
 	private static final Logger log = Logger.getLogger( AbstractSchemaValidator.class );
 
 	protected final HibernateSchemaManagementTool tool;
-	protected final DatabaseModel databaseModel;
+	protected final DataBaseModelExtended databaseModel;
 	protected final SchemaFilter schemaFilter;
 
 	public AbstractSchemaValidator(
 			HibernateSchemaManagementTool tool,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaFilter validateFilter) {
 		this.tool = tool;
 		this.databaseModel = databaseModel;

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.internal.Formatter;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
 import org.hibernate.metamodel.model.relational.spi.Namespace;
@@ -32,7 +33,7 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 
 	public GroupedSchemaMigratorImpl(
 			HibernateSchemaManagementTool tool,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaFilter schemaFilter) {
 		super( tool, databaseModel, schemaFilter );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaValidatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaValidatorImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.tool.schema.internal;
 
 import org.hibernate.dialect.Dialect;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
 import org.hibernate.metamodel.model.relational.spi.Namespace;
 import org.hibernate.metamodel.model.relational.spi.Table;
@@ -26,7 +26,7 @@ public class GroupedSchemaValidatorImpl extends AbstractSchemaValidator {
 
 	public GroupedSchemaValidatorImpl(
 			HibernateSchemaManagementTool tool,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaFilter validateFilter) {
 		super( tool, databaseModel, validateFilter );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/Helper.java
@@ -20,6 +20,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.metamodel.model.creation.spi.DatabaseObjectResolutionContextImpl;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.metamodel.model.relational.spi.Namespace;
 import org.hibernate.metamodel.model.relational.spi.RuntimeDatabaseModelProducer;
@@ -146,7 +147,7 @@ public class Helper {
 		}
 	}
 
-	public static DatabaseModel buildDatabaseModel(MetadataImplementor metadata) {
+	public static DataBaseModelExtended buildDatabaseModel(MetadataImplementor metadata) {
 		final DatabaseObjectResolutionContextImpl dbObjectResolver = new DatabaseObjectResolutionContextImpl();
 		final BootstrapContext bootstrapContext = metadata.getTypeConfiguration()
 				.getMetadataBuildingContext()

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
@@ -64,17 +65,17 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	}
 
 	@Override
-	public SchemaCreator getSchemaCreator(DatabaseModel databaseModel, Map options) {
+	public SchemaCreator getSchemaCreator(DataBaseModelExtended databaseModel, Map options) {
 		return new SchemaCreatorImpl( this, databaseModel, getSchemaFilterProvider( options ).getCreateFilter() );
 	}
 
 	@Override
-	public SchemaDropper getSchemaDropper(DatabaseModel databaseModel, Map options) {
+	public SchemaDropper getSchemaDropper(DataBaseModelExtended databaseModel, Map options) {
 		return new SchemaDropperImpl( this, databaseModel, getSchemaFilterProvider( options ).getDropFilter() );
 	}
 
 	@Override
-	public SchemaMigrator getSchemaMigrator(DatabaseModel databaseModel, Map options) {
+	public SchemaMigrator getSchemaMigrator(DataBaseModelExtended databaseModel, Map options) {
 		if ( determineJdbcMetadaAccessStrategy( options ) == JdbcMetadaAccessStrategy.GROUPED ) {
 			return new GroupedSchemaMigratorImpl(
 					this,
@@ -92,7 +93,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	}
 
 	@Override
-	public SchemaValidator getSchemaValidator(DatabaseModel databaseModel, Map options) {
+	public SchemaValidator getSchemaValidator(DataBaseModelExtended databaseModel, Map options) {
 		if ( determineJdbcMetadaAccessStrategy( options ) == JdbcMetadaAccessStrategy.GROUPED ) {
 			return new GroupedSchemaValidatorImpl(
 					this,

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.internal.Formatter;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
 import org.hibernate.metamodel.model.relational.spi.Namespace;
 import org.hibernate.metamodel.model.relational.spi.Table;
@@ -32,7 +32,7 @@ public class IndividuallySchemaMigratorImpl extends AbstractSchemaMigrator {
 
 	public IndividuallySchemaMigratorImpl(
 			HibernateSchemaManagementTool tool,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaFilter schemaFilter) {
 		super( tool, databaseModel, schemaFilter );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaValidatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaValidatorImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.tool.schema.internal;
 
 import org.hibernate.dialect.Dialect;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
 import org.hibernate.metamodel.model.relational.spi.Namespace;
 import org.hibernate.metamodel.model.relational.spi.Table;
@@ -26,7 +26,7 @@ public class IndividuallySchemaValidatorImpl extends AbstractSchemaValidator {
 
 	public IndividuallySchemaValidatorImpl(
 			HibernateSchemaManagementTool tool,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaFilter validateFilter) {
 		super( tool, databaseModel, validateFilter );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -31,6 +31,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.metamodel.model.relational.spi.AuxiliaryDatabaseObject;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.metamodel.model.relational.spi.Exportable;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
@@ -76,24 +77,24 @@ public class SchemaCreatorImpl implements SchemaCreator {
 	public static final String DEFAULT_IMPORT_FILE = "/import.sql";
 
 	private final HibernateSchemaManagementTool tool;
-	private final DatabaseModel databaseModel;
+	private final DataBaseModelExtended databaseModel;
 	private final SchemaFilter schemaFilter;
 
-	public SchemaCreatorImpl(HibernateSchemaManagementTool tool, DatabaseModel databaseModel) {
+	public SchemaCreatorImpl(HibernateSchemaManagementTool tool, DataBaseModelExtended databaseModel) {
 		this( tool, databaseModel, DefaultSchemaFilter.INSTANCE );
 	}
 
-	public SchemaCreatorImpl(HibernateSchemaManagementTool tool, DatabaseModel databaseModel, SchemaFilter schemaFilter) {
+	public SchemaCreatorImpl(HibernateSchemaManagementTool tool, DataBaseModelExtended databaseModel, SchemaFilter schemaFilter) {
 		this.tool = tool;
 		this.databaseModel = databaseModel;
 		this.schemaFilter = schemaFilter;
 	}
 
-	public SchemaCreatorImpl(DatabaseModel databaseModel, ServiceRegistry serviceRegistry) {
+	public SchemaCreatorImpl(DataBaseModelExtended databaseModel, ServiceRegistry serviceRegistry) {
 		this( databaseModel, serviceRegistry, DefaultSchemaFilter.INSTANCE );
 	}
 
-	public SchemaCreatorImpl(DatabaseModel databaseModel, ServiceRegistry serviceRegistry, SchemaFilter schemaFilter) {
+	public SchemaCreatorImpl(DataBaseModelExtended databaseModel, ServiceRegistry serviceRegistry, SchemaFilter schemaFilter) {
 		SchemaManagementTool smt = serviceRegistry.getService( SchemaManagementTool.class );
 		if ( smt == null || !HibernateSchemaManagementTool.class.isInstance( smt ) ) {
 			smt = new HibernateSchemaManagementTool();

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -27,7 +27,7 @@ import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.metamodel.model.relational.spi.AuxiliaryDatabaseObject;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.Exportable;
 import org.hibernate.metamodel.model.relational.spi.ExportableTable;
 import org.hibernate.metamodel.model.relational.spi.ForeignKey;
@@ -68,17 +68,17 @@ public class SchemaDropperImpl implements SchemaDropper {
 
 	private final HibernateSchemaManagementTool tool;
 	private final SchemaFilter schemaFilter;
-	private final DatabaseModel databaseModel;
+	private final DataBaseModelExtended databaseModel;
 	private final JdbcServices jdbcServices;
 
 
-	public SchemaDropperImpl(HibernateSchemaManagementTool tool, DatabaseModel databaseModel) {
+	public SchemaDropperImpl(HibernateSchemaManagementTool tool, DataBaseModelExtended databaseModel) {
 		this( tool, databaseModel, DefaultSchemaFilter.INSTANCE );
 	}
 
 	public SchemaDropperImpl(
 			HibernateSchemaManagementTool tool,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaFilter schemaFilter) {
 		this.tool = tool;
 		this.schemaFilter = schemaFilter;
@@ -87,11 +87,11 @@ public class SchemaDropperImpl implements SchemaDropper {
 
 	}
 
-	public SchemaDropperImpl(DatabaseModel databaseModel, ServiceRegistry serviceRegistry) {
+	public SchemaDropperImpl(DataBaseModelExtended databaseModel, ServiceRegistry serviceRegistry) {
 		this( databaseModel, serviceRegistry, DefaultSchemaFilter.INSTANCE );
 	}
 
-	public SchemaDropperImpl(DatabaseModel databaseModel, ServiceRegistry serviceRegistry, SchemaFilter schemaFilter) {
+	public SchemaDropperImpl(DataBaseModelExtended databaseModel, ServiceRegistry serviceRegistry, SchemaFilter schemaFilter) {
 		SchemaManagementTool smt = serviceRegistry.getService( SchemaManagementTool.class );
 		if ( smt == null || !HibernateSchemaManagementTool.class.isInstance( smt ) ) {
 			smt = new HibernateSchemaManagementTool();

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
@@ -9,7 +9,7 @@ package org.hibernate.tool.schema.spi;
 import java.util.Map;
 
 import org.hibernate.Incubating;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.service.Service;
 
 /**
@@ -19,11 +19,11 @@ import org.hibernate.service.Service;
  */
 @Incubating
 public interface SchemaManagementTool extends Service {
-	SchemaCreator getSchemaCreator(DatabaseModel databaseModel, Map options);
+	SchemaCreator getSchemaCreator(DataBaseModelExtended databaseModel, Map options);
 
-	SchemaDropper getSchemaDropper(DatabaseModel databaseModel, Map options);
+	SchemaDropper getSchemaDropper(DataBaseModelExtended databaseModel, Map options);
 
-	SchemaMigrator getSchemaMigrator(DatabaseModel databaseModel, Map options);
+	SchemaMigrator getSchemaMigrator(DataBaseModelExtended databaseModel, Map options);
 
-	SchemaValidator getSchemaValidator(DatabaseModel databaseModel, Map options);
+	SchemaValidator getSchemaValidator(DataBaseModelExtended databaseModel, Map options);
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
@@ -13,6 +13,7 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.schema.Action;
 import org.hibernate.tool.schema.SourceType;
@@ -68,13 +69,14 @@ public class SchemaManagementToolCoordinator {
 						ExceptionHandlerLoggedImpl.INSTANCE
 		);
 
-		performScriptAction( actions.getScriptAction(), metadata, tool, serviceRegistry, executionOptions );
-		performDatabaseAction( actions.getDatabaseAction(), metadata, tool, serviceRegistry, executionOptions );
+		final DatabaseModel databaseModel = Helper.buildDatabaseModel( metadata );
+		performScriptAction( actions.getScriptAction(), databaseModel, tool, serviceRegistry, executionOptions );
+		performDatabaseAction( actions.getDatabaseAction(), databaseModel, tool, serviceRegistry, executionOptions );
 
 		if ( actions.getDatabaseAction() == Action.CREATE_DROP ) {
 			//noinspection unchecked
 			delayedDropRegistry.registerOnCloseAction(
-					tool.getSchemaDropper( Helper.buildDatabaseModel( metadata ), configurationValues ).buildDelayedAction(
+					tool.getSchemaDropper( databaseModel, configurationValues ).buildDelayedAction(
 							executionOptions,
 							buildDatabaseTargetDescriptor(
 									configurationValues,
@@ -110,7 +112,7 @@ public class SchemaManagementToolCoordinator {
 	@SuppressWarnings("unchecked")
 	private static void performDatabaseAction(
 			final Action action,
-			MetadataImplementor metadata,
+			DatabaseModel databaseModel,
 			SchemaManagementTool tool,
 			ServiceRegistry serviceRegistry,
 			final ExecutionOptions executionOptions) {
@@ -125,7 +127,7 @@ public class SchemaManagementToolCoordinator {
 						CreateSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaCreator( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaCreator( databaseModel, executionOptions.getConfigurationValues() )
 						.doCreation( executionOptions, createDescriptor, createDescriptor );
 				break;
 			}
@@ -136,7 +138,7 @@ public class SchemaManagementToolCoordinator {
 						DropSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaDropper( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaDropper( databaseModel, executionOptions.getConfigurationValues() )
 						.doDrop( executionOptions, dropDescriptor, dropDescriptor );
 
 				final JpaTargetAndSourceDescriptor createDescriptor = buildDatabaseTargetDescriptor(
@@ -144,7 +146,7 @@ public class SchemaManagementToolCoordinator {
 						CreateSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaCreator( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaCreator( databaseModel, executionOptions.getConfigurationValues() )
 						.doCreation( executionOptions, createDescriptor, createDescriptor );
 				break;
 			}
@@ -154,7 +156,7 @@ public class SchemaManagementToolCoordinator {
 						DropSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaDropper( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaDropper( databaseModel, executionOptions.getConfigurationValues() )
 						.doDrop( executionOptions, dropDescriptor, dropDescriptor );
 				break;
 			}
@@ -164,12 +166,12 @@ public class SchemaManagementToolCoordinator {
 						MigrateSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaMigrator( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaMigrator( databaseModel, executionOptions.getConfigurationValues() )
 						.doMigration( executionOptions, migrateDescriptor );
 				break;
 			}
 			case VALIDATE: {
-				tool.getSchemaValidator( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaValidator( databaseModel, executionOptions.getConfigurationValues() )
 						.doValidation( executionOptions );
 				break;
 			}
@@ -227,7 +229,7 @@ public class SchemaManagementToolCoordinator {
 	@SuppressWarnings("unchecked")
 	private static void performScriptAction(
 			Action scriptAction,
-			MetadataImplementor metadata,
+			DatabaseModel databaseModel,
 			SchemaManagementTool tool,
 			ServiceRegistry serviceRegistry,
 			ExecutionOptions executionOptions) {
@@ -238,7 +240,7 @@ public class SchemaManagementToolCoordinator {
 						CreateSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaCreator( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaCreator( databaseModel, executionOptions.getConfigurationValues() )
 						.doCreation( executionOptions, createDescriptor, createDescriptor );
 				break;
 			}
@@ -249,7 +251,7 @@ public class SchemaManagementToolCoordinator {
 						DropSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaDropper( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaDropper( databaseModel, executionOptions.getConfigurationValues() )
 						.doDrop( executionOptions, dropDescriptor, dropDescriptor );
 
 				final JpaTargetAndSourceDescriptor createDescriptor = buildScriptTargetDescriptor(
@@ -257,7 +259,7 @@ public class SchemaManagementToolCoordinator {
 						CreateSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaCreator( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaCreator( databaseModel, executionOptions.getConfigurationValues() )
 						.doCreation( executionOptions, createDescriptor, createDescriptor );
 				break;
 			}
@@ -267,7 +269,7 @@ public class SchemaManagementToolCoordinator {
 						DropSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaDropper( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaDropper( databaseModel, executionOptions.getConfigurationValues() )
 						.doDrop( executionOptions, dropDescriptor, dropDescriptor );
 				break;
 			}
@@ -277,7 +279,7 @@ public class SchemaManagementToolCoordinator {
 						MigrateSettingSelector.INSTANCE,
 						serviceRegistry
 				);
-				tool.getSchemaMigrator( Helper.buildDatabaseModel( metadata ), executionOptions.getConfigurationValues() )
+				tool.getSchemaMigrator( databaseModel, executionOptions.getConfigurationValues() )
 						.doMigration( executionOptions, migrateDescriptor );
 				break;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
@@ -13,7 +13,7 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.config.spi.ConfigurationService;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.schema.Action;
 import org.hibernate.tool.schema.SourceType;
@@ -50,6 +50,14 @@ public class SchemaManagementToolCoordinator {
 			final ServiceRegistry serviceRegistry,
 			final Map configurationValues,
 			DelayedDropRegistry delayedDropRegistry) {
+		process( Helper.buildDatabaseModel( metadata ), serviceRegistry, configurationValues, delayedDropRegistry );
+	}
+
+	public static void process(
+			final DataBaseModelExtended databaseModel,
+			final ServiceRegistry serviceRegistry,
+			final Map configurationValues,
+			DelayedDropRegistry delayedDropRegistry) {
 		final ActionGrouping actions = ActionGrouping.interpret( configurationValues );
 
 		if ( actions.getDatabaseAction() == Action.NONE && actions.getScriptAction() == Action.NONE ) {
@@ -69,7 +77,6 @@ public class SchemaManagementToolCoordinator {
 						ExceptionHandlerLoggedImpl.INSTANCE
 		);
 
-		final DatabaseModel databaseModel = Helper.buildDatabaseModel( metadata );
 		performScriptAction( actions.getScriptAction(), databaseModel, tool, serviceRegistry, executionOptions );
 		performDatabaseAction( actions.getDatabaseAction(), databaseModel, tool, serviceRegistry, executionOptions );
 
@@ -112,7 +119,7 @@ public class SchemaManagementToolCoordinator {
 	@SuppressWarnings("unchecked")
 	private static void performDatabaseAction(
 			final Action action,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaManagementTool tool,
 			ServiceRegistry serviceRegistry,
 			final ExecutionOptions executionOptions) {
@@ -229,7 +236,7 @@ public class SchemaManagementToolCoordinator {
 	@SuppressWarnings("unchecked")
 	private static void performScriptAction(
 			Action scriptAction,
-			DatabaseModel databaseModel,
+			DataBaseModelExtended databaseModel,
 			SchemaManagementTool tool,
 			ServiceRegistry serviceRegistry,
 			ExecutionOptions executionOptions) {

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -43,6 +43,7 @@ import org.hibernate.metamodel.model.domain.spi.EntityDescriptor;
 import org.hibernate.metamodel.model.domain.spi.EntityHierarchy;
 import org.hibernate.metamodel.model.domain.spi.MappedSuperclassDescriptor;
 import org.hibernate.metamodel.model.domain.spi.PersistentCollectionDescriptor;
+import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.query.sqm.tree.expression.SqmBinaryArithmetic;
 import org.hibernate.query.sqm.tree.expression.SqmLiteral;
 import org.hibernate.sql.ast.produce.metamodel.spi.BasicValuedExpressableType;
@@ -51,7 +52,6 @@ import org.hibernate.sql.ast.produce.metamodel.spi.PolymorphicEntityValuedExpres
 import org.hibernate.sql.ast.produce.sqm.internal.PolymorphicEntityValuedExpressableTypeImpl;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.java.spi.EmbeddableJavaDescriptor;
-import org.hibernate.type.descriptor.java.spi.EntityJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptorRegistry;
 import org.hibernate.type.descriptor.java.spi.MappedSuperclassJavaDescriptor;
@@ -490,7 +490,7 @@ public class TypeConfiguration implements SessionFactoryObserver {
 		return scope.getSessionFactory();
 	}
 
-	public void scope(SessionFactoryImplementor factory, BootstrapContext bootstrapContext) {
+	public MetamodelImplementor scope(SessionFactoryImplementor factory, BootstrapContext bootstrapContext) {
 		log.debugf( "Scoping TypeConfiguration [%s] to SessionFactory [%s]", this, factory );
 
 		for ( Map.Entry<String, String> importEntry : scope.metadataBuildingContext.getMetadataCollector().getImports().entrySet() ) {
@@ -504,7 +504,7 @@ public class TypeConfiguration implements SessionFactoryObserver {
 		scope.setSessionFactory( factory );
 		factory.addObserver( this );
 
-		new RuntimeModelCreationProcess( factory, bootstrapContext, getMetadataBuildingContext() ).execute();
+		return new RuntimeModelCreationProcess( factory, bootstrapContext, getMetadataBuildingContext() ).execute();
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/BaseSchemaUnitTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/BaseSchemaUnitTestCase.java
@@ -24,6 +24,7 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.orm.test.util.DdlTransactionIsolatorTestingImpl;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
@@ -63,7 +64,7 @@ public abstract class BaseSchemaUnitTestCase
 	protected static final String[] NO_MAPPINGS = new String[0];
 
 	private StandardServiceRegistry standardServiceRegistry;
-	private DatabaseModel databaseModel;
+	private DataBaseModelExtended databaseModel;
 	private MetadataImplementor metadata;
 
 	private File output;
@@ -135,7 +136,7 @@ public abstract class BaseSchemaUnitTestCase
 		return schemaScope;
 	}
 
-	public DatabaseModel getDatabaseModel() {
+	public DataBaseModelExtended getDatabaseModel() {
 		return databaseModel;
 	}
 
@@ -282,12 +283,12 @@ public abstract class BaseSchemaUnitTestCase
 	}
 
 	public class SchemaScopeImpl implements SchemaScope {
-		private final DatabaseModel databaseModel;
+		private final DataBaseModelExtended databaseModel;
 		private final StandardServiceRegistry standardServiceRegistry;
 		private final boolean dropSchemaAfterTest;
 
 		public SchemaScopeImpl(
-				DatabaseModel databaseModel,
+				DataBaseModelExtended databaseModel,
 				StandardServiceRegistry standardServiceRegistry, boolean dropSchemaAfterTest) {
 			this.databaseModel = databaseModel;
 			this.standardServiceRegistry = standardServiceRegistry;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schemaupdate/SchemaMigrationTargetScriptCreationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schemaupdate/SchemaMigrationTargetScriptCreationTest.java
@@ -20,6 +20,7 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Environment;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.orm.test.SessionFactoryBasedFunctionalTest;
 import org.hibernate.service.ServiceRegistry;
@@ -72,7 +73,7 @@ public class SchemaMigrationTargetScriptCreationTest extends SessionFactoryBased
 					.buildMetadata();
 			metadata.validate();
 
-			DatabaseModel databaseModel = Helper.buildDatabaseModel( metadata );
+			DataBaseModelExtended databaseModel = Helper.buildDatabaseModel( metadata );
 
 			new SchemaExport( databaseModel, serviceRegistry ).drop( EnumSet.of(
 					TargetType.DATABASE,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schemaupdate/SimpleColumnAdditionMigrationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schemaupdate/SimpleColumnAdditionMigrationTest.java
@@ -10,6 +10,7 @@ import java.util.EnumSet;
 
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
 import org.hibernate.orm.test.tool.BaseSchemaUnitTestCase;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
@@ -45,7 +46,7 @@ public class SimpleColumnAdditionMigrationTest extends BaseSchemaUnitTestCase {
 			assertEquals( 0, schemaUpdate.getExceptions().size() );
 		} );
 
-		final DatabaseModel v2DatabaseModel = createDatabaseModel( RESOURCE_2 );
+		final DataBaseModelExtended v2DatabaseModel = createDatabaseModel( RESOURCE_2 );
 		final SchemaUpdate v2schemaUpdate = new SchemaUpdate( v2DatabaseModel, getStandardServiceRegistry() );
 		v2schemaUpdate.execute( EnumSet.of( TargetType.DATABASE, TargetType.STDOUT ) );
 		assertEquals( 0, v2schemaUpdate.getExceptions().size() );
@@ -53,7 +54,7 @@ public class SimpleColumnAdditionMigrationTest extends BaseSchemaUnitTestCase {
 		new SchemaExport( v2DatabaseModel, getStandardServiceRegistry() ).drop( EnumSet.of( TargetType.DATABASE ) );
 	}
 
-	private DatabaseModel createDatabaseModel(String resource1) {
+	private DataBaseModelExtended createDatabaseModel(String resource1) {
 		final MetadataImplementor v1metadata = (MetadataImplementor) new MetadataSources( getStandardServiceRegistry() )
 				.addResource( resource1 )
 				.buildMetadata();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schemaupdate/TestExtraPhysicalTableTypes.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schemaupdate/TestExtraPhysicalTableTypes.java
@@ -17,7 +17,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
-import org.hibernate.metamodel.model.relational.spi.DatabaseModel;
+import org.hibernate.metamodel.model.relational.spi.DataBaseModelExtended;
 import org.hibernate.orm.test.util.DdlTransactionIsolatorTestingImpl;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.extract.internal.DatabaseInformationImpl;
@@ -89,7 +89,7 @@ public class TestExtraPhysicalTableTypes {
 
 	private InformationExtractorJdbcDatabaseMetaDataImplTest buildInformationExtractorJdbcDatabaseMetaDataImplTest()
 			throws SQLException {
-		final DatabaseModel databaseModel = Helper.buildDatabaseModel( metadata );
+		final DataBaseModelExtended databaseModel = Helper.buildDatabaseModel( metadata );
 		final ConnectionProvider connectionProvider = ssr.getService( ConnectionProvider.class );
 		final DatabaseInformation dbInfo = new DatabaseInformationImpl(
 				ssr,


### PR DESCRIPTION
@sebersole this is a proposal for having a DataBaseModel without the Aux db objects and init commands so that it can be accessed from the MetamodeImplementor without these info.

Not sure if the approach is fine and also the name DataBaseModelExtended probably is not so good.

Any suggestion is more than welcome.
