### PR TITLE
HHH-12164 Upgrade Hibernate Validator used for testing to 6.0.6.Final

### DIFF
--- a/hibernate-c3p0/hibernate-c3p0.gradle
+++ b/hibernate-c3p0/hibernate-c3p0.gradle
@@ -15,8 +15,7 @@ dependencies {
         transitive = true
     }
     // EL libraries are provided scope in Validator
-    testRuntime( libraries.expression_language_api )
-    testRuntime( libraries.expression_language_impl )
+    testRuntime( libraries.expression_language )
 
     if (db.equalsIgnoreCase("oracle")) {
         dependencies {

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -94,8 +94,7 @@ dependencies {
     testCompile( libraries.derby )
 
     testRuntime( "org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec:1.0.0.Final" )
-    testRuntime( libraries.expression_language_api )
-    testRuntime( libraries.expression_language_impl )
+    testRuntime( libraries.expression_language )
     testRuntime( 'jaxen:jaxen:1.1' )
     testRuntime( libraries.javassist )
     testRuntime( libraries.byteBuddy )

--- a/hibernate-spatial/hibernate-spatial.gradle
+++ b/hibernate-spatial/hibernate-spatial.gradle
@@ -42,8 +42,7 @@ dependencies {
         transitive = true
     }
 
-    testRuntime( libraries.expression_language_api )
-    testRuntime( libraries.expression_language_impl )
+    testRuntime( libraries.expression_language )
 
     testRuntime('jaxen:jaxen:1.1')
     testRuntime(libraries.javassist)

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -14,7 +14,9 @@ ext {
     bytemanVersion = '4.0.0-BETA5'
     infinispanVersion = '8.2.5.Final'
     jnpVersion = '5.0.6.CR1'
-    elVersion = '2.2.4'
+
+    hibernateValidatorVersion = '6.0.6.Final'
+    elVersion = '3.0.1-b08'
 
     cdiVersion = '2.0'
     weldVersion = '3.0.0.Final'
@@ -109,10 +111,9 @@ ext {
             mockito:         'org.mockito:mockito-core:2.7.5',
             mockito_inline:  'org.mockito:mockito-inline:2.7.5',
 
-            validator:       'org.hibernate:hibernate-validator:5.2.4.Final',
+            validator:       "org.hibernate.validator:hibernate-validator:${hibernateValidatorVersion}",
             // EL required by Hibernate Validator at test runtime
-            expression_language_api:  "javax.el:javax.el-api:${elVersion}",
-            expression_language_impl: "org.glassfish.web:javax.el:${elVersion}",
+            expression_language: "org.glassfish:javax.el:${elVersion}",
 
             // required by Hibernate Validator at test runtime
             unified_el:      "org.glassfish:javax.el:3.0-b07",


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HHH-12164

I couldn't execute all the tests as it seems there is an issue testing the modules with the new caching API.