### PR TITLE
Changes required for HQL benchmark

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/EmbeddableJavaTypeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/EmbeddableJavaTypeMappingImpl.java
@@ -34,7 +34,7 @@ public class EmbeddableJavaTypeMappingImpl<T>
 
 	@Override
 	public String getTypeName() {
-		return roleName;
+		return componentClassName;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/DisabledCaching.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/DisabledCaching.java
@@ -35,7 +35,7 @@ public class DisabledCaching implements CacheImplementor {
 
 	public DisabledCaching(SessionFactoryImplementor sessionFactory) {
 		this.sessionFactory = sessionFactory;
-		this.regionFactory = sessionFactory.getServiceRegistry().getService( RegionFactory.class );
+		this.regionFactory = sessionFactory.getSessionFactoryOptions().getServiceRegistry().getService( RegionFactory.class );
 	}
 
 	@Override


### PR DESCRIPTION
org.hibernate.cache.internal.DisabledCaching.DisabledCaching() was throwing a NPE

org.hibernate.boot.model.domain.internal.EmbeddableJavaTypeMappingImpl.getTypeName() was returning the role name instead of the class type name for an EmbededType, which caused a CNFE