### PR TITLE
EntitJavaTypeMapping and MutabilityPlan

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/domain/ManagedTypeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/domain/ManagedTypeMapping.java
@@ -9,6 +9,7 @@ package org.hibernate.boot.model.domain;
 import java.util.List;
 import javax.persistence.metamodel.Type.PersistenceType;
 
+import org.hibernate.boot.model.relational.MappedTable;
 import org.hibernate.metamodel.model.domain.RepresentationMode;
 
 /**
@@ -71,4 +72,6 @@ public interface ManagedTypeMapping {
 	 * Get all super managed type mappings associated with this managed type or empty list.
 	 */
 	List<ManagedTypeMapping> getSuperManagedTypeMappings();
+
+	MappedTable getMappedTable();
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/AbstractIdentifiableTypeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/AbstractIdentifiableTypeMapping.java
@@ -42,9 +42,7 @@ public abstract class AbstractIdentifiableTypeMapping
 	private EmbeddedValueMapping declaredIdentifierEmbeddedValueMapping;
 
 	public AbstractIdentifiableTypeMapping(
-			EntityMappingHierarchy entityMappingHierarchy,
-			IdentifiableJavaTypeMapping javaTypeMapping) {
-		super( javaTypeMapping );
+			EntityMappingHierarchy entityMappingHierarchy) {
 		this.entityMappingHierarchy = entityMappingHierarchy;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/AbstractManagedTypeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/AbstractManagedTypeMapping.java
@@ -28,18 +28,19 @@ import org.jboss.logging.Logger;
 public abstract class AbstractManagedTypeMapping implements ManagedTypeMappingImplementor {
 	private static final Logger log = Logger.getLogger( AbstractManagedTypeMapping.class );
 
-	private final ManagedJavaTypeMapping javaTypeMapping;
+	private ManagedJavaTypeMapping javaTypeMapping;
 
 	private ManagedTypeMapping superTypeMapping;
 	private TreeMap<String, PersistentAttributeMapping> declaredAttributeMappings;
 
-	public AbstractManagedTypeMapping(ManagedJavaTypeMapping javaTypeMapping) {
-		this.javaTypeMapping = javaTypeMapping;
-	}
 
 	@Override
 	public JavaTypeMapping getJavaTypeMapping() {
 		return javaTypeMapping;
+	}
+
+	protected void setJavaTypeMapping(ManagedJavaTypeMapping javaTypeMapping) {
+		this.javaTypeMapping = javaTypeMapping;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/AbstractMappedSuperclassMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/AbstractMappedSuperclassMapping.java
@@ -24,9 +24,8 @@ public abstract class AbstractMappedSuperclassMapping
 		implements MappedSuperclassImplementor {
 
 	public AbstractMappedSuperclassMapping(
-			EntityMappingHierarchy entityMappingHierarchy,
-			MappedSuperclassJavaTypeMapping javaTypeMapping) {
-		super( entityMappingHierarchy, javaTypeMapping );
+			EntityMappingHierarchy entityMappingHierarchy) {
+		super( entityMappingHierarchy);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/EntityJavaTypeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/domain/internal/EntityJavaTypeMappingImpl.java
@@ -10,10 +10,15 @@ import org.hibernate.boot.model.domain.EntityJavaTypeMapping;
 import org.hibernate.boot.model.domain.IdentifiableJavaTypeMapping;
 import org.hibernate.boot.model.domain.NotYetResolvedException;
 import org.hibernate.boot.model.source.internal.SourceHelper;
-import org.hibernate.boot.model.source.spi.EntityNamingSource;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.engine.internal.ImmutableEntityEntry;
+import org.hibernate.engine.internal.MutableEntityEntryFactory;
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.type.descriptor.java.MutabilityPlan;
 import org.hibernate.type.descriptor.java.internal.EntityJavaDescriptorImpl;
+import org.hibernate.type.descriptor.java.internal.EntityMutabilityPlanImpl;
 import org.hibernate.type.descriptor.java.spi.IdentifiableJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
 
@@ -21,39 +26,33 @@ import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
  * @author Chris Cranford
  */
 public class EntityJavaTypeMappingImpl<T> extends AbstractIdentifiableJavaTypeMapping<T> implements EntityJavaTypeMapping<T> {
-	private final EntityNamingSource entityNamingSource;
+	private PersistentClass persistentClass;
 
-	public EntityJavaTypeMappingImpl(MetadataBuildingContext buildingContext, EntityNamingSource entityNamingSource, IdentifiableJavaTypeMapping<? super T> superJavaTypeMapping) {
-		super( buildingContext, superJavaTypeMapping );
-
-		this.entityNamingSource = entityNamingSource;
+	public EntityJavaTypeMappingImpl(MetadataBuildingContext buildingContext, PersistentClass persistentClass, IdentifiableJavaTypeMapping<? super T> superJavaTypeMapping) {
+		super( buildingContext, superJavaTypeMapping);
+		this.persistentClass = persistentClass;
 	}
 
 	@Override
 	public String getTypeName() {
-		return entityNamingSource.getTypeName();
+		return StringHelper.isNotEmpty( persistentClass.getClassName() ) ? persistentClass.getClassName() : persistentClass.getEntityName();
 	}
 
 	@Override
 	public String getEntityName() {
-		return entityNamingSource.getEntityName();
+		return persistentClass.getEntityName();
 	}
 
 	@Override
 	public String getJpaEntityName() {
-		return entityNamingSource.getJpaEntityName();
+		return persistentClass.getJpaEntityName();
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public JavaTypeDescriptor<T> getJavaTypeDescriptor() throws NotYetResolvedException {
-		final String name;
-		if ( entityNamingSource.getClassName() == null ) {
-			name = entityNamingSource.getTypeName();
-		}
-		else {
-			name = entityNamingSource.getClassName();
-		}
+
+		final String name =  getTypeName();
 
 		final BootstrapContext bootstrapContext = getMetadataBuildingContext().getBootstrapContext();
 		return SourceHelper.resolveJavaDescriptor(
@@ -62,11 +61,37 @@ public class EntityJavaTypeMappingImpl<T> extends AbstractIdentifiableJavaTypeMa
 				() -> new EntityJavaDescriptorImpl(
 						getTypeName(),
 						getEntityName(),
-						SourceHelper.resolveJavaType( entityNamingSource.getClassName(), bootstrapContext ),
+						SourceHelper.resolveJavaType( name, bootstrapContext ),
 						getSuperType() == null ? null : (IdentifiableJavaDescriptor) getSuperType().getJavaTypeDescriptor(),
-						null,
+						getMutabilityPlan(),
 						null
 				)
 		);
+	}
+
+	private MutabilityPlan getMutabilityPlan() {
+		if ( persistentClass.isMutable() ) {
+			return new EntityMutabilityPlanImpl(
+					MutableEntityEntryFactory.INSTANCE,
+					true
+			);
+		}
+		else {
+			return new EntityMutabilityPlanImpl(
+					(status, loadedState, rowId, id, version, lockMode, existsInDatabase, descriptor, disableVersionIncrement, persistenceContext) -> new ImmutableEntityEntry(
+							status,
+							loadedState,
+							rowId,
+							id,
+							version,
+							lockMode,
+							existsInDatabase,
+							descriptor,
+							disableVersionIncrement,
+							persistenceContext
+					),
+					false
+			);
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/EntityNaming.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/EntityNaming.java
@@ -18,7 +18,7 @@ public interface EntityNaming {
 	 *
 	 * @return The entity class name.
 	 */
-	public String getClassName();
+	String getClassName();
 
 	/**
 	 * The Hibernate entity name.  This might be either:<ul>
@@ -28,7 +28,7 @@ public interface EntityNaming {
 	 *
 	 * @return The Hibernate entity name
 	 */
-	public String getEntityName();
+	String getEntityName();
 
 	/**
 	 * The JPA-specific entity name.  See {@link javax.persistence.Entity#name()} for details.
@@ -36,5 +36,5 @@ public interface EntityNaming {
 	 * @return The JPA entity name, if one was specified.  May return {@code null} if one
 	 * was not explicitly specified.
 	 */
-	public String getJpaEntityName();
+	String getJpaEntityName();
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/EntityNamingSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/EntityNamingSource.java
@@ -20,5 +20,5 @@ public interface EntityNamingSource extends EntityNaming {
 	 *
 	 * @return The reference-able type name
 	 */
-	public String getTypeName();
+	String getTypeName();
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -72,7 +72,6 @@ import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
-import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.Cascade;
@@ -126,8 +125,6 @@ import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.model.IdGeneratorStrategyInterpreter;
 import org.hibernate.boot.model.IdentifierGeneratorDefinition;
 import org.hibernate.boot.model.TypeDefinition;
-import org.hibernate.boot.model.domain.EntityJavaTypeMapping;
-import org.hibernate.boot.model.domain.internal.EntityJavaTypeMappingImpl;
 import org.hibernate.boot.model.relational.MappedColumn;
 import org.hibernate.boot.model.source.spi.EntityNamingSource;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
@@ -1189,46 +1186,20 @@ public final class AnnotationBinder {
 			MetadataBuildingContext metadataBuildingContext) {
 		//we now know what kind of persistent entity it is
 		if ( !inheritanceState.hasParents() ) {
-			return new RootClass(
-					metadataBuildingContext,
-					resolveJavaTypeMapping( inheritanceState, null, metadataBuildingContext )
-			);
+			return new RootClass( metadataBuildingContext );
 		}
 		else if ( InheritanceType.SINGLE_TABLE.equals( inheritanceState.getType() ) ) {
-			return new SingleTableSubclass(
-					superEntity,
-					resolveJavaTypeMapping( inheritanceState, superEntity, metadataBuildingContext ),
-					metadataBuildingContext
-			);
+			return new SingleTableSubclass( superEntity, metadataBuildingContext );
 		}
 		else if ( InheritanceType.JOINED.equals( inheritanceState.getType() ) ) {
-			return new JoinedSubclass(
-					superEntity,
-					resolveJavaTypeMapping( inheritanceState, superEntity, metadataBuildingContext ),
-					metadataBuildingContext
-			);
+			return new JoinedSubclass( superEntity, metadataBuildingContext );
 		}
 		else if ( InheritanceType.TABLE_PER_CLASS.equals( inheritanceState.getType() ) ) {
-			return new UnionSubclass(
-					superEntity,
-					resolveJavaTypeMapping( inheritanceState, superEntity, metadataBuildingContext ),
-					metadataBuildingContext
-			);
+			return new UnionSubclass( superEntity, metadataBuildingContext );
 		}
 		else {
 			throw new AssertionFailure( "Unknown inheritance type: " + inheritanceState.getType() );
 		}
-	}
-
-	private static EntityJavaTypeMapping resolveJavaTypeMapping(
-			InheritanceState inheritanceState,
-			PersistentClass superEntity,
-			MetadataBuildingContext metadataBuildingContext) {
-		return new EntityJavaTypeMappingImpl(
-				metadataBuildingContext,
-				resolveEntityNamingSource( inheritanceState ),
-				superEntity == null ? null : superEntity.getJavaTypeMapping()
-		);
 	}
 
 	private static EntityNamingSource resolveEntityNamingSource(InheritanceState inheritanceState) {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
@@ -293,6 +293,9 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 			}
 			dirtyProperties = ArrayHelper.EMPTY_INT_ARRAY;
 		}
+		else if ( dirtyProperties == null ) {
+			dirtyProperties = ArrayHelper.EMPTY_INT_ARRAY;
+		}
 
 		// check nullability but do not doAfterTransactionCompletion command execute
 		// we'll use scheduled updates for that.

--- a/hibernate-core/src/main/java/org/hibernate/mapping/JoinedSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/JoinedSubclass.java
@@ -24,11 +24,9 @@ public class JoinedSubclass extends Subclass implements TableOwner {
 
 	public JoinedSubclass(
 			EntityMapping superclass,
-			EntityJavaTypeMapping javaTypeMapping,
 			MetadataBuildingContext metadataBuildingContext) {
-		super( superclass, javaTypeMapping, metadataBuildingContext );
+		super( superclass, metadataBuildingContext );
 	}
-
 
 	@Override
 	public Table getTable() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/MappedSuperclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/MappedSuperclass.java
@@ -21,6 +21,7 @@ import org.hibernate.boot.model.domain.MappedSuperclassJavaTypeMapping;
 import org.hibernate.boot.model.domain.PersistentAttributeMapping;
 import org.hibernate.boot.model.domain.ResolutionContext;
 import org.hibernate.boot.model.domain.internal.AbstractMappedSuperclassMapping;
+import org.hibernate.boot.model.relational.MappedTable;
 import org.hibernate.cfg.NotYetImplementedException;
 import org.hibernate.metamodel.model.domain.RepresentationMode;
 
@@ -46,7 +47,8 @@ public class MappedSuperclass extends AbstractMappedSuperclassMapping implements
 			EntityMappingHierarchy entityMappingHierarchy,
 			IdentifiableTypeMapping superIdentifiableTypeMapping,
 			MappedSuperclassJavaTypeMapping javaTypeMapping) {
-		super( entityMappingHierarchy, javaTypeMapping );
+		super( entityMappingHierarchy );
+		setJavaTypeMapping( javaTypeMapping );
 		setSuperManagedType( superIdentifiableTypeMapping );
 	}
 
@@ -239,5 +241,10 @@ public class MappedSuperclass extends AbstractMappedSuperclassMapping implements
 	@Override
 	public Collection<MappedJoin> getMappedJoins() {
 		throw new NotYetImplementedException( "Mapped superclass secondary tables is not implemented yet" );
+	}
+
+	@Override
+	public MappedTable getMappedTable() {
+		throw new MappingException( "This should not be called on a MappedSuperclass" );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -36,7 +36,6 @@ import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.internal.FilterConfiguration;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.StringHelper;
-import org.hibernate.internal.util.collections.EmptyIterator;
 import org.hibernate.internal.util.collections.JoinedIterator;
 import org.hibernate.internal.util.collections.SingletonIterator;
 import org.hibernate.metamodel.model.creation.spi.RuntimeModelCreationContext;
@@ -106,9 +105,8 @@ public abstract class PersistentClass
 
 	public PersistentClass(
 			MetadataBuildingContext metadataBuildingContext,
-			EntityJavaTypeMapping javaTypeMapping,
 			EntityMappingHierarchy entityMappingHierarchy) {
-		super( entityMappingHierarchy, javaTypeMapping );
+		super( entityMappingHierarchy);
 		this.metadataBuildingContext = metadataBuildingContext;
 	}
 
@@ -1158,4 +1156,5 @@ public abstract class PersistentClass
 						getProxyInterface() != null && !ReflectHelper.isFinalClass( getProxyInterface() ))
 		);
 	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
@@ -11,9 +11,9 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.hibernate.MappingException;
-import org.hibernate.boot.model.domain.EntityJavaTypeMapping;
 import org.hibernate.boot.model.domain.PersistentAttributeMapping;
 import org.hibernate.boot.model.domain.ValueMapping;
+import org.hibernate.boot.model.domain.internal.EntityJavaTypeMappingImpl;
 import org.hibernate.boot.model.domain.internal.EntityMappingHierarchyImpl;
 import org.hibernate.boot.model.domain.spi.EntityMappingHierarchyImplementor;
 import org.hibernate.boot.model.relational.MappedTable;
@@ -22,7 +22,6 @@ import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.SingletonIterator;
-import org.hibernate.type.descriptor.java.spi.EntityJavaDescriptor;
 
 /**
  * The root class of an inheritance hierarchy
@@ -52,10 +51,13 @@ public class RootClass extends PersistentClass implements TableOwner {
 	private boolean discriminatorInsertable = true;
 	private int nextSubclassId;
 
-	public RootClass(
-			MetadataBuildingContext metadataBuildingContext,
-			EntityJavaTypeMapping javaTypeMapping) {
-		super( metadataBuildingContext, javaTypeMapping, new EntityMappingHierarchyImpl() );
+	public RootClass(MetadataBuildingContext metadataBuildingContext) {
+		super( metadataBuildingContext, new EntityMappingHierarchyImpl() );
+		setJavaTypeMapping( new EntityJavaTypeMappingImpl(
+				metadataBuildingContext,
+				this,
+				null
+		) );
 		getEntityMappingHierarchy().setRootType( this );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.domain.EntityJavaTypeMapping;
 import org.hibernate.boot.model.domain.EntityMapping;
+import org.hibernate.boot.model.domain.internal.EntityJavaTypeMappingImpl;
 import org.hibernate.boot.model.relational.MappedColumn;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.internal.util.collections.JoinedIterator;
@@ -23,9 +24,8 @@ public class SingleTableSubclass extends Subclass {
 
 	public SingleTableSubclass(
 			EntityMapping superclass,
-			EntityJavaTypeMapping javaTypeMapping,
 			MetadataBuildingContext metadataBuildingContext) {
-		super( superclass, javaTypeMapping, metadataBuildingContext );
+		super( superclass, metadataBuildingContext );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
@@ -15,6 +15,7 @@ import org.hibernate.boot.model.domain.EntityJavaTypeMapping;
 import org.hibernate.boot.model.domain.EntityMappingHierarchy;
 import org.hibernate.boot.model.domain.IdentifiableTypeMapping;
 import org.hibernate.boot.model.domain.PersistentAttributeMapping;
+import org.hibernate.boot.model.domain.internal.EntityJavaTypeMappingImpl;
 import org.hibernate.boot.model.domain.spi.IdentifiableTypeMappingImplementor;
 import org.hibernate.boot.model.relational.MappedTable;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -26,18 +27,31 @@ import org.hibernate.internal.util.collections.SingletonIterator;
  * A sublass in a table-per-class-hierarchy mapping
  * @author Gavin King
  */
-public class Subclass extends PersistentClass {
+public abstract class Subclass extends PersistentClass {
 	private IdentifiableTypeMapping superclass;
 	private Class classPersisterClass;
 	private final int subclassId;
 	
 	public Subclass(
 			IdentifiableTypeMapping superclass,
-			EntityJavaTypeMapping javaTypeMapping,
 			MetadataBuildingContext metadataBuildingContext) {
-		super( metadataBuildingContext, javaTypeMapping, superclass.getEntityMappingHierarchy() );
+		super( metadataBuildingContext, superclass.getEntityMappingHierarchy() );
+		setJavaTypeMapping( resolveJavaTypeMapping(
+				superclass,
+				metadataBuildingContext
+		) );
 		this.superclass = superclass;
 		this.subclassId = ( (IdentifiableTypeMappingImplementor) superclass ).nextSubclassId();
+	}
+
+	private EntityJavaTypeMapping resolveJavaTypeMapping(
+			IdentifiableTypeMapping superEntity,
+			MetadataBuildingContext metadataBuildingContext) {
+		return new EntityJavaTypeMappingImpl(
+				metadataBuildingContext,
+				this,
+				superEntity == null ? null : superEntity.getJavaTypeMapping()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/UnionSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/UnionSubclass.java
@@ -23,9 +23,8 @@ public class UnionSubclass extends Subclass implements TableOwner {
 
 	public UnionSubclass(
 			PersistentClass superclass,
-			EntityJavaTypeMapping javaTypeMapping,
 			MetadataBuildingContext metadataBuildingContext) {
-		super( superclass, javaTypeMapping, metadataBuildingContext );
+		super( superclass, metadataBuildingContext );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicSingularPersistentAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicSingularPersistentAttribute.java
@@ -34,6 +34,7 @@ import org.hibernate.query.sqm.tree.expression.domain.SqmNavigableReference;
 import org.hibernate.query.sqm.tree.expression.domain.SqmSingularAttributeReferenceBasic;
 import org.hibernate.query.sqm.tree.from.SqmFrom;
 import org.hibernate.sql.JdbcValueMapper;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.produce.metamodel.spi.BasicValuedExpressableType;
 import org.hibernate.sql.ast.produce.spi.ColumnReferenceQualifier;
 import org.hibernate.sql.ast.tree.spi.expression.ColumnReference;
@@ -233,6 +234,7 @@ public class BasicSingularPersistentAttribute<O, J>
 	public void dehydrate(
 			Object value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 //		if ( valueConverter != null ) {
 //			value = valueConverter.toRelationalValue( value, session );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityIdentifierCompositeAggregatedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityIdentifierCompositeAggregatedImpl.java
@@ -26,6 +26,7 @@ import org.hibernate.metamodel.model.domain.spi.NavigableVisitationStrategy;
 import org.hibernate.metamodel.model.domain.spi.SingularPersistentAttribute;
 import org.hibernate.metamodel.model.relational.spi.Column;
 import org.hibernate.procedure.ParameterMisuseException;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.tree.spi.expression.domain.NavigableReference;
 import org.hibernate.sql.results.spi.QueryResult;
 import org.hibernate.sql.results.spi.QueryResultCreationContext;
@@ -225,12 +226,14 @@ public class EntityIdentifierCompositeAggregatedImpl<O,J>
 	public void dehydrate(
 			Object value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 		final Object[] values = (Object[]) value;
 		getEmbeddedDescriptor().visitStateArrayContributors(
 				contributor -> contributor.dehydrate(
 						values[ contributor.getStateArrayPosition() ],
 						jdbcValueCollector,
+						clause,
 						session
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityIdentifierCompositeNonAggregatedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityIdentifierCompositeNonAggregatedImpl.java
@@ -24,6 +24,7 @@ import org.hibernate.metamodel.model.domain.spi.NavigableVisitationStrategy;
 import org.hibernate.metamodel.model.domain.spi.SingularPersistentAttribute;
 import org.hibernate.metamodel.model.relational.spi.Column;
 import org.hibernate.procedure.ParameterMisuseException;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.tree.spi.expression.domain.NavigableReference;
 import org.hibernate.sql.results.spi.QueryResult;
 import org.hibernate.sql.results.spi.QueryResultCreationContext;
@@ -132,12 +133,14 @@ public class EntityIdentifierCompositeNonAggregatedImpl<O,J>
 	public void dehydrate(
 			Object value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 		final Object[] values = (Object[]) value;
 		getEmbeddedDescriptor().visitStateArrayContributors(
 				contributor -> contributor.dehydrate(
-						values[ contributor.getStateArrayPosition() ],
+						values[contributor.getStateArrayPosition()],
 						jdbcValueCollector,
+						clause,
 						session
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityIdentifierSimpleImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityIdentifierSimpleImpl.java
@@ -22,6 +22,7 @@ import org.hibernate.metamodel.model.domain.spi.NavigableVisitationStrategy;
 import org.hibernate.metamodel.model.domain.spi.SingularPersistentAttribute;
 import org.hibernate.metamodel.model.domain.spi.StateArrayContributor;
 import org.hibernate.metamodel.model.relational.spi.Column;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.tree.spi.expression.domain.NavigableReference;
 import org.hibernate.sql.results.internal.ScalarQueryResultImpl;
 import org.hibernate.sql.results.spi.QueryResult;
@@ -178,6 +179,7 @@ public class EntityIdentifierSimpleImpl<O,J>
 	public void dehydrate(
 			Object value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 		jdbcValueCollector.collect( value, this, getBoundColumn() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralPersistentAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralPersistentAttributeImpl.java
@@ -37,6 +37,7 @@ import org.hibernate.query.sqm.produce.spi.SqmCreationContext;
 import org.hibernate.query.sqm.tree.expression.domain.SqmNavigableContainerReference;
 import org.hibernate.query.sqm.tree.expression.domain.SqmPluralAttributeReference;
 import org.hibernate.query.sqm.tree.from.SqmFrom;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.produce.spi.ColumnReferenceQualifier;
 import org.hibernate.sql.results.spi.Fetch;
 import org.hibernate.sql.results.spi.FetchParent;
@@ -372,6 +373,7 @@ public class PluralPersistentAttributeImpl extends AbstractPersistentAttribute i
 	public void dehydrate(
 			Object value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularPersistentAttributeEntity.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularPersistentAttributeEntity.java
@@ -53,6 +53,7 @@ import org.hibernate.query.sqm.tree.expression.domain.SqmNavigableContainerRefer
 import org.hibernate.query.sqm.tree.expression.domain.SqmNavigableReference;
 import org.hibernate.query.sqm.tree.expression.domain.SqmSingularAttributeReferenceEntity;
 import org.hibernate.query.sqm.tree.from.SqmFrom;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.JoinType;
 import org.hibernate.sql.ast.produce.metamodel.spi.EntityValuedExpressableType;
 import org.hibernate.sql.ast.produce.metamodel.spi.Fetchable;
@@ -390,6 +391,7 @@ public class SingularPersistentAttributeEntity<O,J>
 	public void dehydrate(
 			Object value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 		// todo (6.0) (fk-to-id) : another place where we assume association fks point to the pks
 		getEntityDescriptor().getHierarchy().getIdentifierDescriptor().dehydrate(
@@ -399,6 +401,7 @@ public class SingularPersistentAttributeEntity<O,J>
 						getEntityDescriptor().getHierarchy().getIdentifierDescriptor(),
 						foreignKey.getColumnMappings().findReferringColumn( targetColumn )
 				),
+				clause,
 				session
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/VersionDescriptorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/VersionDescriptorImpl.java
@@ -20,6 +20,7 @@ import org.hibernate.metamodel.model.domain.spi.StateArrayContributor;
 import org.hibernate.metamodel.model.domain.spi.VersionDescriptor;
 import org.hibernate.metamodel.model.domain.spi.VersionSupport;
 import org.hibernate.metamodel.model.relational.spi.Column;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.produce.metamodel.spi.BasicValuedExpressableType;
 import org.hibernate.sql.ast.tree.spi.expression.domain.NavigableReference;
 import org.hibernate.sql.results.internal.ScalarQueryResultImpl;
@@ -162,6 +163,7 @@ public class VersionDescriptorImpl<O,J>
 	public void dehydrate(
 			Object value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 		jdbcValueCollector.collect( value, this, getBoundColumn() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/spi/Writeable.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/spi/Writeable.java
@@ -9,6 +9,7 @@ package org.hibernate.metamodel.model.domain.spi;
 import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.model.relational.spi.Column;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.type.descriptor.java.spi.BasicJavaDescriptor;
 
 /**
@@ -36,6 +37,7 @@ public interface Writeable<D,I> {
 	default void dehydrate(
 			I value,
 			JdbcValueCollector jdbcValueCollector,
+			Clause clause,
 			SharedSessionContractImplementor session) {
 		throw new NotYetImplementedFor6Exception( getClass() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/Column.java
@@ -9,7 +9,6 @@ package org.hibernate.metamodel.model.relational.spi;
 import java.util.Comparator;
 
 import org.hibernate.NotYetImplementedFor6Exception;
-import org.hibernate.annotations.Remove;
 import org.hibernate.sql.ast.produce.spi.ColumnReferenceQualifier;
 import org.hibernate.sql.ast.produce.spi.QualifiableSqlExpressable;
 import org.hibernate.sql.ast.produce.spi.SqlAstProducerContext;
@@ -57,21 +56,11 @@ public interface Column extends QualifiableSqlExpressable {
 
 	BasicJavaDescriptor getJavaTypeDescriptor();
 
-
 	@Override
 	default Expression createSqlExpression(
 			ColumnReferenceQualifier qualifier,
 			SqlAstProducerContext creationContext) {
 		return new ColumnReference( qualifier, this );
-	}
-
-	/**
-	 * @deprecated Use {@link #getSqlTypeDescriptor()} instead
-	 */
-	@Deprecated
-	@Remove
-	default int getJdbcType() {
-		return getSqlTypeDescriptor().getJdbcTypeCode();
 	}
 
 	Comparator<Column> COLUMN_COMPARATOR = Comparator.comparing( Column::getExpression );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/Clause.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/Clause.java
@@ -19,6 +19,7 @@ import org.hibernate.metamodel.model.domain.spi.StateArrayContributor;
 public enum Clause {
 	INSERT( AllowableParameterType.STANDARD_INSERT_INCLUSION_CHECK ),
 	UPDATE( AllowableParameterType.STANDARD_UPDATE_INCLUSION_CHECK),
+	DELETE( AllowableParameterType.STANDARD_UPDATE_INCLUSION_CHECK),
 	SELECT( stateArrayContributor -> true ),
 	FROM( stateArrayContributor -> true ),
 	WHERE( stateArrayContributor -> true ),

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/spi/from/AbstractTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/spi/from/AbstractTableGroup.java
@@ -18,7 +18,7 @@ import org.hibernate.sql.ast.tree.spi.expression.ColumnReference;
  */
 public abstract class AbstractTableGroup
 		extends AbstractColumnReferenceQualifier
-		implements TableGroup, ColumnReferenceQualifier {
+		implements TableGroup {
 
 	private final TableSpace tableSpace;
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/AbstractEntityInitializer.java
@@ -133,7 +133,7 @@ public abstract class AbstractEntityInitializer implements EntityInitializer {
 		//		1) resolve the value(s) into its identifier representation
 		final Object id = concreteDescriptor.getHierarchy()
 				.getIdentifierDescriptor()
-				.resolveHydratedState( identifierHydratedState, rowProcessingState, session.getSession(), null );
+				.resolveHydratedState( identifierHydratedState, rowProcessingState, session, null );
 
 		//		2) build and register an EntityKey
 		this.entityKey = new EntityKey( id, concreteDescriptor.getEntityDescriptor() );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/EntityRootInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/EntityRootInitializer.java
@@ -8,7 +8,6 @@ package org.hibernate.sql.results.internal;
 
 import org.hibernate.LockMode;
 import org.hibernate.metamodel.model.domain.spi.EntityDescriptor;
-import org.hibernate.sql.results.spi.EntityInitializer;
 import org.hibernate.sql.results.spi.EntitySqlSelectionGroup;
 
 /**
@@ -16,8 +15,7 @@ import org.hibernate.sql.results.spi.EntitySqlSelectionGroup;
  * @author Steve Ebersole
  */
 public class EntityRootInitializer
-		extends AbstractEntityInitializer
-		implements EntityInitializer {
+		extends AbstractEntityInitializer {
 	public EntityRootInitializer(
 			EntityDescriptor entityDescriptor,
 			EntitySqlSelectionGroup sqlSelectionMappings,

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/EntityMutabilityPlanImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/EntityMutabilityPlanImpl.java
@@ -17,15 +17,12 @@ import org.hibernate.type.descriptor.java.spi.EntityMutabilityPlan;
  * @author Steve Ebersole
  */
 public class EntityMutabilityPlanImpl implements EntityMutabilityPlan {
-	private final EntityDescriptor entityDescriptor;
 	private final EntityEntryFactory entityEntryFactory;
 	private final boolean isMutable;
 
 	public EntityMutabilityPlanImpl(
-			EntityDescriptor entityDescriptor,
 			EntityEntryFactory entityEntryFactory,
 			boolean isMutable) {
-		this.entityDescriptor = entityDescriptor;
 		this.entityEntryFactory = entityEntryFactory;
 		this.isMutable = isMutable;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/crud/ColumnInsertableFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/crud/ColumnInsertableFalseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.crud;
+
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.orm.test.SessionFactoryBasedFunctionalTest;
+
+import org.hibernate.testing.junit5.FailureExpected;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+/**
+ * @author Andrea Boriero
+ */
+@FailureExpected( value= "Insertable false has not yet been implementd" )
+public class ColumnInsertableFalseTest extends SessionFactoryBasedFunctionalTest {
+	@Override
+	protected void applyMetadataSources(MetadataSources metadataSources) {
+		super.applyMetadataSources( metadataSources );
+		metadataSources.addAnnotatedClass( Price.class );
+	}
+
+	@Override
+	protected boolean exportSchema() {
+		return true;
+	}
+
+	@Test
+	public void testIt() {
+		Price price = new Price( 1, "first", 12 );
+		sessionFactoryScope().inTransaction(
+				session -> {
+					session.save( price );
+				}
+		);
+
+//		sessionFactoryScope().inTransaction(
+//				session -> {
+//					session.update( price );
+//					price.setInitalPrice( 20 );
+//					price.setDescription( "first item" );
+//				}
+//		);
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					assertThat( session.get( Price.class, price.getId() ).getInitalPrice(), equalTo( 12 ) );
+					assertThat( session.get( Price.class, price.getId() ).getDescription(), nullValue() );
+				}
+		);
+	}
+
+	@Entity
+	public static class Price {
+		@Id
+		private Integer id;
+
+		@Column(insertable = false)
+		private String description;
+
+		private Integer initalPrice;
+
+		public Price() {
+		}
+
+		@Override
+		public int hashCode() {
+			return super.hashCode();
+		}
+
+		public Price(Integer id, String description, Integer initalPrice) {
+			this.id = id;
+			this.description = description;
+			this.initalPrice = initalPrice;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getInitalPrice() {
+			return initalPrice;
+		}
+
+		public void setInitalPrice(Integer initalPrice) {
+			this.initalPrice = initalPrice;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+	}
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/crud/ColumnInsertableFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/crud/ColumnInsertableFalseTest.java
@@ -14,7 +14,6 @@ import javax.persistence.Id;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.orm.test.SessionFactoryBasedFunctionalTest;
 
-import org.hibernate.testing.junit5.FailureExpected;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -25,7 +24,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author Andrea Boriero
  */
-@FailureExpected( value= "Insertable false has not yet been implementd" )
 public class ColumnInsertableFalseTest extends SessionFactoryBasedFunctionalTest {
 	@Override
 	protected void applyMetadataSources(MetadataSources metadataSources) {
@@ -39,26 +37,34 @@ public class ColumnInsertableFalseTest extends SessionFactoryBasedFunctionalTest
 	}
 
 	@Test
-	public void testIt() {
-		Price price = new Price( 1, "first", 12 );
+	public void testSavingAndUpdating() {
 		sessionFactoryScope().inTransaction(
 				session -> {
+					Price price = new Price( 1, "first", 12 );
 					session.save( price );
 				}
 		);
 
-//		sessionFactoryScope().inTransaction(
-//				session -> {
-//					session.update( price );
-//					price.setInitalPrice( 20 );
-//					price.setDescription( "first item" );
-//				}
-//		);
+		sessionFactoryScope().inTransaction(
+				session -> {
+					assertThat( session.get( Price.class, 1 ).getInitalPrice(), equalTo( 12 ) );
+					assertThat( session.get( Price.class, 1 ).getDescription(), nullValue() );
+				}
+		);
 
 		sessionFactoryScope().inTransaction(
 				session -> {
-					assertThat( session.get( Price.class, price.getId() ).getInitalPrice(), equalTo( 12 ) );
-					assertThat( session.get( Price.class, price.getId() ).getDescription(), nullValue() );
+					Price price = session.get( Price.class, 1 );
+					session.update( price );
+					price.setInitalPrice( 20 );
+					price.setDescription( "first item" );
+				}
+		);
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					assertThat( session.get( Price.class, 1 ).getInitalPrice(), equalTo( 20 ) );
+					assertThat( session.get( Price.class, 1 ).getDescription(), nullValue() );
 				}
 		);
 	}
@@ -68,7 +74,7 @@ public class ColumnInsertableFalseTest extends SessionFactoryBasedFunctionalTest
 		@Id
 		private Integer id;
 
-		@Column(insertable = false)
+		@Column(insertable = false, updatable = false)
 		private String description;
 
 		private Integer initalPrice;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EmbeddableWithColumnInsertableFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EmbeddableWithColumnInsertableFalseTest.java
@@ -1,0 +1,172 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.crud;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.orm.test.SessionFactoryBasedFunctionalTest;
+
+import org.hibernate.testing.junit5.FailureExpected;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+
+/**
+ * @author Andrea Boriero
+ */
+public class EmbeddableWithColumnInsertableFalseTest extends SessionFactoryBasedFunctionalTest {
+	@Override
+	protected void applyMetadataSources(MetadataSources metadataSources) {
+		super.applyMetadataSources( metadataSources );
+		metadataSources.addAnnotatedClass( Person.class );
+	}
+
+	@Override
+	protected boolean exportSchema() {
+		return true;
+	}
+
+	@Test
+	public void testSaving() {
+		sessionFactoryScope().inTransaction(
+				session -> {
+					Name name = new Name( "Fabiana", "Fab" );
+					Person person = new Person( 1, name, 33 );
+					session.save( person );
+				} );
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					Person person = session.get( Person.class, 1 );
+					assertThat( person.getName().getSecondName(), nullValue() );
+					assertThat( person.getName().getFirstName(), is( "Fabiana" ) );
+				} );
+	}
+
+	@Test
+	@FailureExpected("The dirty checking does not work for Embedded , the stored loadedState contains a ref to the Name object, so" +
+			" when the test executes person.getName().setFirstName( \"Fabi\" ) the loadedState Name changes as well making it equals to the current value ")
+	public void testUpdating() {
+		sessionFactoryScope().inTransaction(
+				session -> {
+					Name name = new Name( "Fabiana", "Fab" );
+					Person person = new Person( 1, name, 33 );
+					session.save( person );
+				} );
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					Person person = session.get( Person.class, 1 );
+					assertThat( person.getName().getSecondName(), nullValue() );
+					assertThat( person.getName().getFirstName(), is( "Fabiana" ) );
+				} );
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					Person person = session.get( Person.class, 1 );
+					person.setAge( 34 );
+					Name name = person.getName();
+					name.setSecondName( "Fabi" );
+					name.setFirstName( "Fabi" );
+				} );
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					Person person = session.get( Person.class, 1 );
+					Name name = person.getName();
+					assertThat( name.getSecondName(), nullValue() );
+					assertThat( name.getFirstName(), is( "Fabi" ) );
+				} );
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+		@Id
+		private Integer id;
+
+		private Name name;
+
+		private Integer age;
+
+		public Person() {
+		}
+
+		@Override
+		public int hashCode() {
+			return super.hashCode();
+		}
+
+		public Person(Integer id, Name name, Integer age) {
+			this.id = id;
+			this.name = name;
+			this.age = age;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Name getName() {
+			return name;
+		}
+
+		public void setName(Name name) {
+			this.name = name;
+		}
+
+		public Integer getAge() {
+			return age;
+		}
+
+		public void setAge(Integer age) {
+			this.age = age;
+		}
+	}
+
+
+	@Embeddable
+	public static class Name {
+		private String firstName;
+		@Column(insertable = false, updatable = false)
+		private String secondName;
+
+		public Name() {
+		}
+
+		public Name(String firstName, String secondName) {
+			this.firstName = firstName;
+			this.secondName = secondName;
+		}
+
+		public String getFirstName() {
+			return firstName;
+		}
+
+		public String getSecondName() {
+			return secondName;
+		}
+
+		public void setSecondName(String secondName) {
+			this.secondName = secondName;
+		}
+
+		public void setFirstName(String firstName) {
+			this.firstName = firstName;
+		}
+	}
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithOneToManyCrudTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithOneToManyCrudTest.java
@@ -1,0 +1,66 @@
+package org.hibernate.orm.test.crud;
+
+import java.util.Calendar;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.orm.test.SessionFactoryBasedFunctionalTest;
+import org.hibernate.orm.test.support.domains.gambit.EntityWithOneToMany;
+import org.hibernate.orm.test.support.domains.gambit.SimpleEntity;
+
+import org.hibernate.testing.junit5.FailureExpected;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+/**
+ * @author Andrea Boriero
+ */
+@FailureExpected( value= "Persist and find og OneToMany has not yet been implemented" )
+public class EntityWithOneToManyCrudTest extends SessionFactoryBasedFunctionalTest {
+	@Override
+	protected void applyMetadataSources(MetadataSources metadataSources) {
+		super.applyMetadataSources( metadataSources );
+		metadataSources.addAnnotatedClass( EntityWithOneToMany.class );
+		metadataSources.addAnnotatedClass( SimpleEntity.class );
+	}
+
+	@Override
+	protected boolean exportSchema() {
+		return true;
+	}
+
+	@Test
+	public void testSave() {
+		EntityWithOneToMany entity = new EntityWithOneToMany( 1, "first", Integer.MAX_VALUE );
+
+		SimpleEntity other = new SimpleEntity(
+				2,
+				Calendar.getInstance().getTime(),
+				null,
+				Integer.MAX_VALUE,
+				Long.MAX_VALUE,
+				null
+		);
+
+		entity.addOther( other );
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					session.save( other );
+				} );
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					session.save( entity );
+				} );
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					EntityWithOneToMany retrieved = session.get( EntityWithOneToMany.class, 1 );
+					assertThat( retrieved, notNullValue() );
+				} );
+
+	}
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/support/domains/gambit/EntityWithOneToMany.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/support/domains/gambit/EntityWithOneToMany.java
@@ -1,0 +1,65 @@
+package org.hibernate.orm.test.support.domains.gambit;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+/**
+ * @author Andrea Boriero
+ */
+@Entity
+public class EntityWithOneToMany {
+	private Integer id;
+
+	// alphabetical
+	private String name;
+	private List<SimpleEntity> others = new ArrayList<>(  );
+	private Integer someInteger;
+
+	public EntityWithOneToMany(Integer id, String name, Integer someInteger) {
+		this.id = id;
+		this.name = name;
+		this.someInteger = someInteger;
+	}
+
+	@Id
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@OneToMany
+	public List<SimpleEntity> getOthers() {
+		return others;
+	}
+
+	public void setOthers(List<SimpleEntity> others) {
+		this.others = others;
+	}
+
+	public Integer getSomeInteger() {
+		return someInteger;
+	}
+
+	public void setSomeInteger(Integer someInteger) {
+		this.someInteger = someInteger;
+	}
+
+	public void addOther(SimpleEntity other) {
+		others.add( other );
+	}
+}
+


### PR DESCRIPTION
apart some clean up, the important change is related with the `EntityJavaTypeMappingImpl` , to avoid having a JTD with a null  `MutabilityPlan`, the `PersistentClass` is passed in the `EntityJavaTypeMappingImpl` constructor so it can be used later when `EntityJavaTypeMappingImpl#getJavaTypeDescriptor()` is called to determine if the `PersistentClass` is mutable or not and build the correct `MutabilityPlan`.
This change required also changing all the RootClass and SubClass constructors.

```
public RootClass(MetadataBuildingContext metadataBuildingContext) {
		super( metadataBuildingContext, new EntityMappingHierarchyImpl() );
		setJavaTypeMapping( new EntityJavaTypeMappingImpl(
				metadataBuildingContext,
				this,
				null
		) );
		getEntityMappingHierarchy().setRootType( this );
	}

```
```
public Subclass(
			IdentifiableTypeMapping superclass,
			MetadataBuildingContext metadataBuildingContext) {
		super( metadataBuildingContext, superclass.getEntityMappingHierarchy() );
		setJavaTypeMapping( resolveJavaTypeMapping(
				superclass,
				metadataBuildingContext
		) );
		this.superclass = superclass;
		this.subclassId = ( (IdentifiableTypeMappingImplementor) superclass ).nextSubclassId();
	}

	private EntityJavaTypeMapping resolveJavaTypeMapping(
			IdentifiableTypeMapping superEntity,
			MetadataBuildingContext metadataBuildingContext) {
		return new EntityJavaTypeMappingImpl(
				metadataBuildingContext,
				this,
				superEntity == null ? null : superEntity.getJavaTypeMapping()
		);
	}
```
