### PR TITLE
fix EntityWithManyToOneSelfReferenceCrudTest

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingleTableEntityDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingleTableEntityDescriptor.java
@@ -238,7 +238,7 @@ public class SingleTableEntityDescriptor<T> extends AbstractEntityDescriptor<T> 
 				// NOTE : at least according to the argument name (`unresolvedId`), the
 				// 		incoming id value should already be unresolved - so do not
 				// 		unresolve it again
-				 getHierarchy().getIdentifierDescriptor().unresolve( unresolvedId, session ),
+				getHierarchy().getIdentifierDescriptor().unresolve( unresolvedId, session ),
 				//unresolvedId,
 				(jdbcValue, type, boundColumn) -> {
 					insertStatement.addTargetColumnReference( new ColumnReference( boundColumn ) );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/internal/StandardSqlExpressionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/internal/StandardSqlExpressionResolver.java
@@ -32,7 +32,9 @@ public class StandardSqlExpressionResolver implements SqlExpressionResolver {
 	private final Function<Expression, Expression> normalizer;
 	private final BiConsumer<Expression,SqlSelection> selectionConsumer;
 
-	private Map<SqlExpressable,SqlSelection> sqlSelectionMap;
+	private int position = 0;
+
+//	private Map<SqlExpressable,SqlSelection> sqlSelectionMap;
 	private int nonEmptySelections = 0;
 
 	public StandardSqlExpressionResolver(
@@ -61,28 +63,30 @@ public class StandardSqlExpressionResolver implements SqlExpressionResolver {
 			Expression expression,
 			BasicJavaDescriptor javaTypeDescriptor,
 			TypeConfiguration typeConfiguration) {
-		final SqlSelection existing;
-		if ( sqlSelectionMap == null ) {
-			sqlSelectionMap = new HashMap<>();
-			existing = null;
-		}
-		else {
-			existing = sqlSelectionMap.get( expression.getExpressable() );
-		}
+//		final SqlSelection existing;
+//		if ( sqlSelectionMap == null ) {
+//			sqlSelectionMap = new HashMap<>();
+//			existing = null;
+//		}
+//		else {
+//			existing = sqlSelectionMap.get( expression.getExpressable() );
+//		}
+//
+//		if ( existing != null ) {
+//			return existing;
+//		}
 
-		if ( existing != null ) {
-			return existing;
-		}
 
 
 		final SqlSelection sqlSelection = expression.createSqlSelection(
 				nonEmptySelections + 1,
-				sqlSelectionMap.size(),
+				position,
 				javaTypeDescriptor,
 				typeConfiguration
 		);
+		position++;
 
-		sqlSelectionMap.put( expression.getExpressable(), sqlSelection );
+//		sqlSelectionMap.put( expression.getExpressable(), sqlSelection );
 		selectionConsumer.accept( expression, sqlSelection );
 
 		if ( ! ( sqlSelection instanceof EmptySqlSelection ) ) {
@@ -97,12 +101,13 @@ public class StandardSqlExpressionResolver implements SqlExpressionResolver {
 
 	@Override
 	public SqlSelection emptySqlSelection() {
-		final EmptySqlSelection selection = new EmptySqlSelection( sqlSelectionMap.size() );
-		sqlSelectionMap.put(
-				() -> null,
-				selection
-		);
+		final EmptySqlSelection selection = new EmptySqlSelection( position );
+//		sqlSelectionMap.put(
+//				() -> null,
+//				selection
+//		);
 
+		position++;
 		final QuerySpec querySpec = querySpecSupplier.get();
 		querySpec.getSelectClause().addSqlSelection( selection );
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/metamodel/internal/MetamodelSelectBuilderProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/metamodel/internal/MetamodelSelectBuilderProcess.java
@@ -465,8 +465,9 @@ public class MetamodelSelectBuilderProcess
 
 		fetchParentStack.push( fetchParent );
 		try {
-			fetchParent.getNavigableContainer().visitKeyFetchables( fetchableConsumer );
-			fetchParent.getNavigableContainer().visitFetchables( fetchableConsumer );
+			NavigableContainer navigableContainer = fetchParent.getNavigableContainer();
+			navigableContainer.visitKeyFetchables( fetchableConsumer );
+			navigableContainer.visitFetchables( fetchableConsumer );
 		}
 		finally {
 			fetchParentStack.pop();

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/sqm/internal/IdSelectGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/sqm/internal/IdSelectGenerator.java
@@ -6,8 +6,11 @@
  */
 package org.hibernate.sql.ast.produce.sqm.internal;
 
+import java.util.List;
+
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
+import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.SingletonStack;
@@ -37,6 +40,8 @@ import org.hibernate.sql.ast.tree.spi.predicate.Junction;
 import org.hibernate.sql.ast.tree.spi.predicate.Predicate;
 import org.hibernate.sql.ast.produce.spi.SqlAstCreationContext;
 import org.hibernate.sql.results.spi.DomainResultCreationState;
+import org.hibernate.sql.results.spi.Fetch;
+import org.hibernate.sql.results.spi.FetchParent;
 import org.hibernate.sql.results.spi.SqlSelectionGroupNode;
 
 /**
@@ -146,8 +151,18 @@ public class IdSelectGenerator extends SqmSelectToSqlAstConverter {
 			}
 
 			@Override
+			public SqlAliasBaseGenerator getSqlAliasBaseGenerator() {
+				throw new NotYetImplementedFor6Exception( getClass() );
+			}
+
+			@Override
 			public boolean fetchAllAttributes() {
 				return false;
+			}
+
+			@Override
+			public List<Fetch> visitFetches(FetchParent fetchParent) {
+				throw new NotYetImplementedFor6Exception( getClass() );
 			}
 
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/sqm/spi/SqmSelectToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/produce/sqm/spi/SqmSelectToSqlAstConverter.java
@@ -37,6 +37,7 @@ import org.hibernate.query.sqm.tree.select.SqmDynamicInstantiationTarget;
 import org.hibernate.query.sqm.tree.select.SqmSelection;
 import org.hibernate.sql.ast.produce.internal.PerQuerySpecSqlExpressionResolver;
 import org.hibernate.sql.ast.produce.internal.SqlAstSelectDescriptorImpl;
+import org.hibernate.sql.ast.produce.metamodel.spi.AssociationKey;
 import org.hibernate.sql.ast.produce.metamodel.spi.Fetchable;
 import org.hibernate.sql.ast.produce.metamodel.spi.SqlAliasBaseGenerator;
 import org.hibernate.sql.ast.produce.spi.ColumnReferenceQualifier;
@@ -220,6 +221,8 @@ public class SqmSelectToSqlAstConverter
 		return null;
 	}
 
+	private List<AssociationKey> fetchedAssociationKey = new ArrayList<>(  );
+
 	@Override
 	public List<Fetch> visitFetches(FetchParent fetchParent) {
 		final NavigableContainerReference parentNavigableReference = (NavigableContainerReference) getNavigableReferenceStack().getCurrent();
@@ -230,7 +233,13 @@ public class SqmSelectToSqlAstConverter
 
 		final Consumer<Fetchable> fetchableConsumer = fetchable -> {
 			LockMode lockMode = LockMode.READ;
-
+			final AssociationKey associationKey = fetchable.getAssociationKey();
+			if ( associationKey != null ) {
+				if ( fetchedAssociationKey.contains( associationKey ) ) {
+					return;
+				}
+				fetchedAssociationKey.add( associationKey );
+			}
 			FetchTiming fetchTiming = fetchable.getMappedFetchStrategy().getTiming();
 			boolean joined = false;
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/entity/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/entity/AbstractEntityInitializer.java
@@ -213,9 +213,14 @@ public abstract class AbstractEntityInitializer implements EntityInitializer {
 		resolveEntityKey( rowProcessingState );
 
 		// todo (6.0) : should this really be true?  what about fetches that resolve to null?
-		assert entityKey != null;
-
-		SqlResultsLogger.INSTANCE.debugf( "Hydrated EntityKey (%s): %s", getNavigablePath(), entityKey.getIdentifier() );
+//		assert entityKey != null;
+		if ( entityKey != null ) {
+			SqlResultsLogger.INSTANCE.debugf(
+					"Hydrated EntityKey (%s): %s",
+					getNavigablePath(),
+					entityKey.getIdentifier()
+			);
+		}
 	}
 
 	private EntityDescriptor determineConcreteEntityDescriptor(
@@ -262,6 +267,9 @@ public abstract class AbstractEntityInitializer implements EntityInitializer {
 		//		1) resolve the hydrated identifier value(s) into its identifier representation
 		final Object id  = identifierAssembler.assemble( rowProcessingState, rowProcessingState.getJdbcValuesSourceProcessingState().getProcessingOptions() );
 
+		if ( id == null ) {
+			return;
+		}
 		//		2) build the EntityKey
 		this.entityKey = new EntityKey( id, concreteDescriptor.getEntityDescriptor() );
 
@@ -277,6 +285,9 @@ public abstract class AbstractEntityInitializer implements EntityInitializer {
 
 	@Override
 	public void resolve(RowProcessingState rowProcessingState) {
+		if ( entityKey == null ) {
+			return;
+		}
 		final Object entityIdentifier = entityKey.getIdentifier();
 
 		SqlResultsLogger.INSTANCE.tracef( "Beginning Initializer#resolve process for entity (%s) : %s", getNavigablePath().getFullPath(), entityIdentifier );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/entity/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/entity/AbstractEntityInitializer.java
@@ -107,7 +107,10 @@ public abstract class AbstractEntityInitializer implements EntityInitializer {
 		if ( entityDescriptor.getHierarchy().getDiscriminatorDescriptor() != null ) {
 			assert discriminatorResult != null;
 			discriminatorAssembler = discriminatorResult.createResultAssembler(
-					initializer -> { throw new UnsupportedOperationException( "Registering an Initializer as part of Entity discriminator is illegal" ); },
+					initializer -> {
+						throw new UnsupportedOperationException(
+								"Registering an Initializer as part of Entity discriminator is illegal" );
+					},
 					creationState,
 					context
 			);
@@ -119,7 +122,10 @@ public abstract class AbstractEntityInitializer implements EntityInitializer {
 		if ( entityDescriptor.getHierarchy().getVersionDescriptor() != null ) {
 			assert versionResult != null;
 			this.versionAssembler = versionResult.createResultAssembler(
-					initializer -> { throw new UnsupportedOperationException( "Registering an Initializer as part of Entity version is illegal" ); },
+					initializer -> {
+						throw new UnsupportedOperationException(
+								"Registering an Initializer as part of Entity version is illegal" );
+					},
 					creationState,
 					context
 			);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/spi/DomainResultCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/spi/DomainResultCreationState.java
@@ -9,7 +9,6 @@ package org.hibernate.sql.results.spi;
 import java.util.List;
 
 import org.hibernate.LockMode;
-import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.internal.util.collections.Stack;
 import org.hibernate.sql.ast.produce.metamodel.spi.Fetchable;
 import org.hibernate.sql.ast.produce.metamodel.spi.SqlAliasBaseGenerator;
@@ -29,9 +28,7 @@ public interface DomainResultCreationState {
 
 	Stack<NavigableReference> getNavigableReferenceStack();
 
-	default SqlAliasBaseGenerator getSqlAliasBaseGenerator() {
-		throw new NotYetImplementedFor6Exception( getClass() );
-	}
+	SqlAliasBaseGenerator getSqlAliasBaseGenerator();
 
 	boolean fetchAllAttributes();
 
@@ -56,9 +53,7 @@ public interface DomainResultCreationState {
 	 * the {@link JdbcValues} being processed.  For {@link org.hibernate.engine.FetchTiming#DELAYED} this
 	 * parameter has no effect
 	 */
-	default List<Fetch> visitFetches(FetchParent fetchParent) {
-		throw new NotYetImplementedFor6Exception( getClass() );
-	}
+	List<Fetch> visitFetches(FetchParent fetchParent);
 
 	TableSpace getCurrentTableSpace();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithManyToOneJoinTableCrudTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithManyToOneJoinTableCrudTest.java
@@ -53,6 +53,7 @@ public class EntityWithManyToOneJoinTableCrudTest extends SessionFactoryBasedFun
 		sessionFactoryScope().inTransaction( session -> session.save( other ) );
 		sessionFactoryScope().inTransaction( session -> session.save( entity ) );
 
+
 		sessionFactoryScope().inTransaction(
 				session -> {
 					final EntityWithManyToOneJoinTable loaded = session.get( EntityWithManyToOneJoinTable.class, 1 );
@@ -70,7 +71,6 @@ public class EntityWithManyToOneJoinTableCrudTest extends SessionFactoryBasedFun
 					assertThat( loaded.getSomeInteger(), equalTo( Integer.MAX_VALUE ) );
 				}
 		);
-
 
 		sessionFactoryScope().inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithManyToOneJoinTableCrudTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithManyToOneJoinTableCrudTest.java
@@ -53,7 +53,6 @@ public class EntityWithManyToOneJoinTableCrudTest extends SessionFactoryBasedFun
 		sessionFactoryScope().inTransaction( session -> session.save( other ) );
 		sessionFactoryScope().inTransaction( session -> session.save( entity ) );
 
-
 		sessionFactoryScope().inTransaction(
 				session -> {
 					final EntityWithManyToOneJoinTable loaded = session.get( EntityWithManyToOneJoinTable.class, 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithManyToOneSelfReferenceCrudTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/crud/EntityWithManyToOneSelfReferenceCrudTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -44,6 +45,7 @@ public class EntityWithManyToOneSelfReferenceCrudTest extends SessionFactoryBase
 				"first",
 				Integer.MAX_VALUE
 		);
+
 		final EntityWithManyToOneSelfReference entity2 = new EntityWithManyToOneSelfReference(
 				2,
 				"second",
@@ -60,10 +62,12 @@ public class EntityWithManyToOneSelfReferenceCrudTest extends SessionFactoryBase
 				session -> {
 					final EntityWithManyToOneSelfReference loaded = session.get(
 							EntityWithManyToOneSelfReference.class,
-							1
+							2
 					);
 					assert loaded != null;
-					assertThat( loaded.getName(), equalTo( "first" ) );
+					assertThat( loaded.getName(), equalTo( "second" ) );
+					assert loaded.getOther() != null;
+					assertThat( loaded.getOther().getName(), equalTo( "first" ) );
 				}
 		);
 
@@ -71,12 +75,11 @@ public class EntityWithManyToOneSelfReferenceCrudTest extends SessionFactoryBase
 				session -> {
 					final EntityWithManyToOneSelfReference loaded = session.get(
 							EntityWithManyToOneSelfReference.class,
-							2
+							1
 					);
 					assert loaded != null;
-					assertThat( loaded.getName(), equalTo( "second" ) );
-					assert loaded.getOther() != null;
-					assertThat( loaded.getOther().getName(), equalTo( "first" ) );
+					assertThat( loaded.getName(), equalTo( "first" ) );
+					assertThat( loaded.getOther(), nullValue() );
 				}
 		);
 
@@ -114,6 +117,16 @@ public class EntityWithManyToOneSelfReferenceCrudTest extends SessionFactoryBase
 							String.class
 					).uniqueResult();
 					assertThat( value, equalTo( "second" ) );
+				}
+		);
+
+		sessionFactoryScope().inTransaction(
+				session -> {
+					final EntityWithManyToOneSelfReference queryResult = session.createQuery(
+							"select e from EntityWithManyToOneSelfReference e where e.other.name = 'first'",
+							EntityWithManyToOneSelfReference.class
+					).uniqueResult();
+					assertThat( queryResult.getName(), equalTo( "second" ) );
 				}
 		);
 	}


### PR DESCRIPTION
@sebersole This fixed the problem with the EntityWithManyToOneSelfReferenceCrudTest, the issue was related to the fact the selection was missing the columns related to related to the joined entity so instead of having a 
```
select
        e1_0.id,
        e1_0.name,
        o1_0.id,
        o1_0.name,
        o1_0.someInteger,
        e1_0.someInteger 
    from
        EntityWithManyToOneSelfReference as e1_0 
    left outer join
        (
            EntityWithManyToOneSelfReference as o1_0
        )  
            on e1_0.other=o1_0.id 
    where
        e1_0.id=?
```
the SQL query was 
```
select
        e1_0.id,
        e1_0.name,
        o1_0.someInteger
        
    from
        EntityWithManyToOneSelfReference as e1_0 
    left outer join
        (
            EntityWithManyToOneSelfReference as o1_0
        )  
            on e1_0.other=o1_0.id 
    where
        e1_0.id=?
```
