### PR TITLE
HHH-11147 - Allow enhanced entities to be returned in a completely uninitialized state	

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/Helper.java
@@ -15,6 +15,7 @@ import org.hibernate.bytecode.BytecodeLogger;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.SessionFactoryRegistry;
+import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
@@ -49,10 +50,14 @@ public class Helper {
 			final ToOne toOne = (ToOne) value;
 			if ( toOne.isLazy() ) {
 				if ( toOne.isUnwrapProxy() ) {
+					if ( toOne instanceof OneToOne ) {
+						return false;
+					}
 					// include it in the base fetch group so long as the config allows
 					// using the FK to create an "enhancement proxy"
 					return allowEnhancementAsProxy;
 				}
+
 			}
 
 			return true;

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -60,7 +60,6 @@ public class LazyAttributeLoadingInterceptor extends AbstractLazyLoadInterceptor
 	@Override
 	protected Object handleWrite(Object target, String attributeName, Object oldValue, Object newValue) {
 		if ( !isAttributeLoaded( attributeName ) ) {
-			fetchAttribute( target, attributeName );
 			attributeInitialized( attributeName );
 		}
 		return newValue;


### PR DESCRIPTION
with this PR all tests are passing.

The change in the `Helper` avoid loading the OneToOne immediately.

The changes in `BidirectionalLazyTest` bring back the assertions as they are on master.

The change in `LazyAttributeLoadingInterceptor` brings back the behaviour as it is on master and fixes the failures in `MergeEnhancedDetachedOrphanRemovalTest`.


