### PR TITLE
HHH-11147 - Allow enhanced entities to be returned in a completely uninitialized state

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -64,6 +64,18 @@ public final class Hibernate {
 		else if ( proxy instanceof PersistentCollection ) {
 			( (PersistentCollection) proxy ).forceInitialization();
 		}
+
+		// todo : consider bytecode enhancement handling
+//		else if ( proxy instanceof PersistentAttributeInterceptable ) {
+//			final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) proxy;
+//			final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
+//			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
+//				( (EnhancementAsProxyLazinessInterceptor) interceptor ).forceInitialize( proxy, null );
+//			}
+//			else if ( interceptor instanceof LazyAttributeLoadingInterceptor ) {
+//				( (LazyAttributeLoadingInterceptor) interceptor ).fetchAttribute()
+//			}
+//		}
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -8,6 +8,7 @@ package org.hibernate;
 
 import java.util.Iterator;
 
+import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.HibernateIterator;
@@ -75,6 +76,13 @@ public final class Hibernate {
 	public static boolean isInitialized(Object proxy) {
 		if ( proxy instanceof HibernateProxy ) {
 			return !( (HibernateProxy) proxy ).getHibernateLazyInitializer().isUninitialized();
+		}
+		else if ( proxy instanceof PersistentAttributeInterceptable ) {
+			final PersistentAttributeInterceptor interceptor = ( (PersistentAttributeInterceptable) proxy ).$$_hibernate_getInterceptor();
+			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
+				return false;
+			}
+			return true;
 		}
 		else if ( proxy instanceof PersistentCollection ) {
 			return ( (PersistentCollection) proxy ).wasInitialized();
@@ -187,7 +195,10 @@ public final class Hibernate {
 
 		if ( entity instanceof PersistentAttributeInterceptable ) {
 			PersistentAttributeInterceptor interceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
-			if ( interceptor != null && interceptor instanceof LazyAttributeLoadingInterceptor ) {
+			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
+				return false;
+			}
+			if ( interceptor instanceof LazyAttributeLoadingInterceptor ) {
 				return ( (LazyAttributeLoadingInterceptor) interceptor ).isAttributeLoaded( propertyName );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -65,6 +65,7 @@ import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
 
 import static org.hibernate.cfg.AvailableSettings.ACQUIRE_CONNECTIONS;
+import static org.hibernate.cfg.AvailableSettings.ALLOW_ENHANCEMENT_AS_PPROXY;
 import static org.hibernate.cfg.AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS;
 import static org.hibernate.cfg.AvailableSettings.ALLOW_REFRESH_DETACHED_ENTITY;
 import static org.hibernate.cfg.AvailableSettings.ALLOW_UPDATE_OUTSIDE_TRANSACTION;
@@ -195,6 +196,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private boolean orderUpdatesEnabled;
 	private boolean orderInsertsEnabled;
 	private boolean postInsertIdentifierDelayed;
+	private boolean enhancementAsProxyEnabled;
 
 	// JPA callbacks
 	private boolean callbacksEnabled;
@@ -248,6 +250,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	private boolean nativeExceptionHandling51Compliance;
 	private int queryStatisticsMaxSize;
+
 
 	@SuppressWarnings({"WeakerAccess", "deprecation"})
 	public SessionFactoryOptionsBuilder(StandardServiceRegistry serviceRegistry, BootstrapContext context) {
@@ -345,6 +348,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.defaultNullPrecedence = NullPrecedence.parse( defaultNullPrecedence );
 		this.orderUpdatesEnabled = ConfigurationHelper.getBoolean( ORDER_UPDATES, configurationSettings );
 		this.orderInsertsEnabled = ConfigurationHelper.getBoolean( ORDER_INSERTS, configurationSettings );
+		this.enhancementAsProxyEnabled = ConfigurationHelper.getBoolean( ALLOW_ENHANCEMENT_AS_PPROXY, configurationSettings );
 
 		this.callbacksEnabled = ConfigurationHelper.getBoolean( JPA_CALLBACKS_ENABLED, configurationSettings, true );
 
@@ -1053,6 +1057,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public boolean areJPACallbacksEnabled() {
 		return callbacksEnabled;
+	}
+
+	@Override
+	public boolean isEnhancementAsProxyEnabled() {
+		return enhancementAsProxyEnabled;
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -442,4 +442,9 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	public boolean areJPACallbacksEnabled() {
 		return delegate.areJPACallbacksEnabled();
 	}
+
+	@Override
+	public boolean isEnhancementAsProxyEnabled() {
+		return delegate.isEnhancementAsProxyEnabled();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -308,4 +308,8 @@ public interface SessionFactoryOptions {
 		return true;
 	}
 
+	/**
+	 * Can bytecode-enhanced entity classes be used as a "proxy"?
+	 */
+	boolean isEnhancementAsProxyEnabled();
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/BytecodeLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/BytecodeLogger.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.bytecode;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface BytecodeLogger extends BasicLogger {
+	String NAME = "org.hibernate.orm.bytecode";
+
+	Logger LOGGER = Logger.getLogger( NAME );
+
+	boolean TRACE_ENABLED = LOGGER.isTraceEnabled();
+	boolean DEBUG_ENABLED = LOGGER.isDebugEnabled();
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/LazyPropertyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/LazyPropertyInitializer.java
@@ -7,8 +7,10 @@
 package org.hibernate.bytecode.enhance.spi;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Set;
 
+import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -32,9 +34,18 @@ public interface LazyPropertyInitializer {
 		}
 	};
 
+	/**
+	 * @deprecated Prefer the form of these methods defined on
+	 * {@link BytecodeLazyAttributeInterceptor} instead
+	 */
+	@Deprecated
 	interface InterceptorImplementor {
-		Set<String> getInitializedLazyAttributeNames();
-		void attributeInitialized(String name);
+		default Set<String> getInitializedLazyAttributeNames() {
+			return Collections.emptySet();
+		}
+
+		default void attributeInitialized(String name) {
+		}
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/AbstractInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/AbstractInterceptor.java
@@ -1,0 +1,161 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.bytecode.enhance.spi.interceptor;
+
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+/**
+ * @author Steve Ebersole
+ */
+public abstract class AbstractInterceptor implements PersistentAttributeInterceptor, SessionAssociableInterceptor {
+	private final String entityName;
+
+	private transient SharedSessionContractImplementor session;
+	private boolean allowLoadOutsideTransaction;
+	private String sessionFactoryUuid;
+
+	@SuppressWarnings("WeakerAccess")
+	public AbstractInterceptor(String entityName) {
+		this.entityName = entityName;
+	}
+
+	public String getEntityName() {
+		return entityName;
+	}
+
+	@Override
+	public SharedSessionContractImplementor getLinkedSession() {
+		return session;
+	}
+
+	@Override
+	public void setSession(SharedSessionContractImplementor session) {
+		this.session = session;
+		if ( session != null && !allowLoadOutsideTransaction ) {
+			this.allowLoadOutsideTransaction = session.getFactory().getSessionFactoryOptions().isInitializeLazyStateOutsideTransactionsEnabled();
+			if ( this.allowLoadOutsideTransaction ) {
+				this.sessionFactoryUuid = session.getFactory().getUuid();
+			}
+		}
+	}
+
+	@Override
+	public void unsetSession() {
+		this.session = null;
+	}
+
+	@Override
+	public boolean allowLoadOutsideTransaction() {
+		return allowLoadOutsideTransaction;
+	}
+
+	@Override
+	public String getSessionFactoryUuid() {
+		return sessionFactoryUuid;
+	}
+
+	/**
+	 * Handle the case of reading an attribute.  The result is what is returned to the caller
+	 */
+	protected abstract Object handleRead(Object target, String attributeName, Object value);
+
+	/**
+	 * Handle the case of writing an attribute.  The result is what is set as the entity state
+	 */
+	protected abstract Object handleWrite(Object target, String attributeName, Object oldValue, Object newValue);
+
+	@Override
+	public boolean readBoolean(Object obj, String name, boolean oldValue) {
+		return (Boolean) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public boolean writeBoolean(Object obj, String name, boolean oldValue, boolean newValue) {
+		return (Boolean) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public byte readByte(Object obj, String name, byte oldValue) {
+		return (Byte) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public byte writeByte(Object obj, String name, byte oldValue, byte newValue) {
+		return (Byte) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public char readChar(Object obj, String name, char oldValue) {
+		return (Character) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public char writeChar(Object obj, String name, char oldValue, char newValue) {
+		return (char) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public short readShort(Object obj, String name, short oldValue) {
+		return (Short) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public short writeShort(Object obj, String name, short oldValue, short newValue) {
+		return (Short) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public int readInt(Object obj, String name, int oldValue) {
+		return (Integer) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public int writeInt(Object obj, String name, int oldValue, int newValue) {
+		return (Integer) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public float readFloat(Object obj, String name, float oldValue) {
+		return (Float) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public float writeFloat(Object obj, String name, float oldValue, float newValue) {
+		return (Float) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public double readDouble(Object obj, String name, double oldValue) {
+		return (Double) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public double writeDouble(Object obj, String name, double oldValue, double newValue) {
+		return (Double) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public long readLong(Object obj, String name, long oldValue) {
+		return (Long) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public long writeLong(Object obj, String name, long oldValue, long newValue) {
+		return (Long) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public Object readObject(Object obj, String name, Object oldValue) {
+		return handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public Object writeObject(Object obj, String name, Object oldValue, Object newValue) {
+		return handleWrite( obj, name, oldValue, newValue );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/AbstractLazyLoadInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/AbstractLazyLoadInterceptor.java
@@ -11,156 +11,16 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 /**
  * @author Steve Ebersole
  */
-public abstract class AbstractLazyLoadInterceptor implements BytecodeLazyAttributeInterceptor {
+public abstract class AbstractLazyLoadInterceptor extends AbstractInterceptor implements BytecodeLazyAttributeInterceptor {
 
-	private final String entityName;
-
-	private transient SharedSessionContractImplementor session;
-	private boolean allowLoadOutsideTransaction;
-	private String sessionFactoryUuid;
-
+	@SuppressWarnings("unused")
 	public AbstractLazyLoadInterceptor(String entityName) {
-		this.entityName = entityName;
+		super( entityName );
 	}
 
+	@SuppressWarnings("WeakerAccess")
 	public AbstractLazyLoadInterceptor(String entityName, SharedSessionContractImplementor session) {
+		super( entityName );
 		setSession( session );
-		this.entityName = entityName;
-	}
-
-	public String getEntityName() {
-		return entityName;
-	}
-
-	@Override
-	public SharedSessionContractImplementor getLinkedSession() {
-		return session;
-	}
-
-	@Override
-	public boolean allowLoadOutsideTransaction() {
-		return allowLoadOutsideTransaction;
-	}
-
-	@Override
-	public String getSessionFactoryUuid() {
-		return sessionFactoryUuid;
-	}
-
-	@Override
-	public final void setSession(SharedSessionContractImplementor session) {
-		this.session = session;
-		if ( session != null && !allowLoadOutsideTransaction ) {
-			this.allowLoadOutsideTransaction = session.getFactory().getSessionFactoryOptions().isInitializeLazyStateOutsideTransactionsEnabled();
-			if ( this.allowLoadOutsideTransaction ) {
-				this.sessionFactoryUuid = session.getFactory().getUuid();
-			}
-		}
-	}
-
-	@Override
-	public final void unsetSession() {
-		this.session = null;
-	}
-
-
-	/**
-	 * Handle the case of reading an attribute.  The result is what is returned to the caller
-	 */
-	protected abstract Object handleRead(Object target, String attributeName, Object value);
-
-	/**
-	 * Handle the case of writing an attribute.  The result is what is set as the entity state
-	 */
-	protected abstract Object handleWrite(Object target, String attributeName, Object oldValue, Object newValue);
-
-	@Override
-	public boolean readBoolean(Object obj, String name, boolean oldValue) {
-		return (Boolean) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public boolean writeBoolean(Object obj, String name, boolean oldValue, boolean newValue) {
-		return (Boolean) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public byte readByte(Object obj, String name, byte oldValue) {
-		return (Byte) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public byte writeByte(Object obj, String name, byte oldValue, byte newValue) {
-		return (Byte) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public char readChar(Object obj, String name, char oldValue) {
-		return (Character) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public char writeChar(Object obj, String name, char oldValue, char newValue) {
-		return (char) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public short readShort(Object obj, String name, short oldValue) {
-		return (Short) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public short writeShort(Object obj, String name, short oldValue, short newValue) {
-		return (Short) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public int readInt(Object obj, String name, int oldValue) {
-		return (Integer) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public int writeInt(Object obj, String name, int oldValue, int newValue) {
-		return (Integer) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public float readFloat(Object obj, String name, float oldValue) {
-		return (Float) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public float writeFloat(Object obj, String name, float oldValue, float newValue) {
-		return (Float) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public double readDouble(Object obj, String name, double oldValue) {
-		return (Double) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public double writeDouble(Object obj, String name, double oldValue, double newValue) {
-		return (Double) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public long readLong(Object obj, String name, long oldValue) {
-		return (Long) handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public long writeLong(Object obj, String name, long oldValue, long newValue) {
-		return (Long) handleWrite( obj, name, oldValue, newValue );
-	}
-
-	@Override
-	public Object readObject(Object obj, String name, Object oldValue) {
-		return handleRead( obj, name, oldValue );
-	}
-
-	@Override
-	public Object writeObject(Object obj, String name, Object oldValue, Object newValue) {
-		return handleWrite( obj, name, oldValue, newValue );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/AbstractLazyLoadInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/AbstractLazyLoadInterceptor.java
@@ -1,0 +1,166 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.bytecode.enhance.spi.interceptor;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+/**
+ * @author Steve Ebersole
+ */
+public abstract class AbstractLazyLoadInterceptor implements BytecodeLazyAttributeInterceptor {
+
+	private final String entityName;
+
+	private transient SharedSessionContractImplementor session;
+	private boolean allowLoadOutsideTransaction;
+	private String sessionFactoryUuid;
+
+	public AbstractLazyLoadInterceptor(String entityName) {
+		this.entityName = entityName;
+	}
+
+	public AbstractLazyLoadInterceptor(String entityName, SharedSessionContractImplementor session) {
+		setSession( session );
+		this.entityName = entityName;
+	}
+
+	public String getEntityName() {
+		return entityName;
+	}
+
+	@Override
+	public SharedSessionContractImplementor getLinkedSession() {
+		return session;
+	}
+
+	@Override
+	public boolean allowLoadOutsideTransaction() {
+		return allowLoadOutsideTransaction;
+	}
+
+	@Override
+	public String getSessionFactoryUuid() {
+		return sessionFactoryUuid;
+	}
+
+	@Override
+	public final void setSession(SharedSessionContractImplementor session) {
+		this.session = session;
+		if ( session != null && !allowLoadOutsideTransaction ) {
+			this.allowLoadOutsideTransaction = session.getFactory().getSessionFactoryOptions().isInitializeLazyStateOutsideTransactionsEnabled();
+			if ( this.allowLoadOutsideTransaction ) {
+				this.sessionFactoryUuid = session.getFactory().getUuid();
+			}
+		}
+	}
+
+	@Override
+	public final void unsetSession() {
+		this.session = null;
+	}
+
+
+	/**
+	 * Handle the case of reading an attribute.  The result is what is returned to the caller
+	 */
+	protected abstract Object handleRead(Object target, String attributeName, Object value);
+
+	/**
+	 * Handle the case of writing an attribute.  The result is what is set as the entity state
+	 */
+	protected abstract Object handleWrite(Object target, String attributeName, Object oldValue, Object newValue);
+
+	@Override
+	public boolean readBoolean(Object obj, String name, boolean oldValue) {
+		return (Boolean) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public boolean writeBoolean(Object obj, String name, boolean oldValue, boolean newValue) {
+		return (Boolean) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public byte readByte(Object obj, String name, byte oldValue) {
+		return (Byte) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public byte writeByte(Object obj, String name, byte oldValue, byte newValue) {
+		return (Byte) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public char readChar(Object obj, String name, char oldValue) {
+		return (Character) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public char writeChar(Object obj, String name, char oldValue, char newValue) {
+		return (char) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public short readShort(Object obj, String name, short oldValue) {
+		return (Short) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public short writeShort(Object obj, String name, short oldValue, short newValue) {
+		return (Short) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public int readInt(Object obj, String name, int oldValue) {
+		return (Integer) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public int writeInt(Object obj, String name, int oldValue, int newValue) {
+		return (Integer) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public float readFloat(Object obj, String name, float oldValue) {
+		return (Float) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public float writeFloat(Object obj, String name, float oldValue, float newValue) {
+		return (Float) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public double readDouble(Object obj, String name, double oldValue) {
+		return (Double) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public double writeDouble(Object obj, String name, double oldValue, double newValue) {
+		return (Double) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public long readLong(Object obj, String name, long oldValue) {
+		return (Long) handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public long writeLong(Object obj, String name, long oldValue, long newValue) {
+		return (Long) handleWrite( obj, name, oldValue, newValue );
+	}
+
+	@Override
+	public Object readObject(Object obj, String name, Object oldValue) {
+		return handleRead( obj, name, oldValue );
+	}
+
+	@Override
+	public Object writeObject(Object obj, String name, Object oldValue, Object newValue) {
+		return handleWrite( obj, name, oldValue, newValue );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeLazyAttributeInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeLazyAttributeInterceptor.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.bytecode.enhance.spi.interceptor;
+
+import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface BytecodeLazyAttributeInterceptor
+		extends PersistentAttributeInterceptor, LazyPropertyInitializer.InterceptorImplementor {
+	SharedSessionContractImplementor getLinkedSession();
+
+	boolean allowLoadOutsideTransaction();
+
+	String getSessionFactoryUuid();
+
+	void setSession(SharedSessionContractImplementor session);
+
+	void unsetSession();
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeLazyAttributeInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeLazyAttributeInterceptor.java
@@ -6,22 +6,27 @@
  */
 package org.hibernate.bytecode.enhance.spi.interceptor;
 
-import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
  * @author Steve Ebersole
  */
-public interface BytecodeLazyAttributeInterceptor
-		extends PersistentAttributeInterceptor, LazyPropertyInitializer.InterceptorImplementor {
+@Incubating
+public interface BytecodeLazyAttributeInterceptor extends PersistentAttributeInterceptor {
+
+	String getEntityName();
+
+	Object getIdentifier();
+
 	SharedSessionContractImplementor getLinkedSession();
-
-	boolean allowLoadOutsideTransaction();
-
-	String getSessionFactoryUuid();
 
 	void setSession(SharedSessionContractImplementor session);
 
 	void unsetSession();
+
+	boolean allowLoadOutsideTransaction();
+
+	String getSessionFactoryUuid();
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeLazyAttributeInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeLazyAttributeInterceptor.java
@@ -6,27 +6,36 @@
  */
 package org.hibernate.bytecode.enhance.spi.interceptor;
 
+import java.util.Set;
+
 import org.hibernate.Incubating;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
  * @author Steve Ebersole
  */
 @Incubating
-public interface BytecodeLazyAttributeInterceptor extends PersistentAttributeInterceptor {
-
+public interface BytecodeLazyAttributeInterceptor extends PersistentAttributeInterceptor, SessionAssociableInterceptor {
+	/**
+	 * The name of the entity this interceptor is meant to intercept
+	 */
 	String getEntityName();
 
+	/**
+	 * The id of the entity instance this interceptor is associated with
+	 */
 	Object getIdentifier();
 
-	SharedSessionContractImplementor getLinkedSession();
+	/**
+	 * The names of all lazy attributes which have been initialized
+	 */
+	@Override
+	Set<String> getInitializedLazyAttributeNames();
 
-	void setSession(SharedSessionContractImplementor session);
+	/**
+	 * Callback from the enhanced class that an attribute has been read or written
+	 */
+	void attributeInitialized(String name);
 
-	void unsetSession();
 
-	boolean allowLoadOutsideTransaction();
-
-	String getSessionFactoryUuid();
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.LockMode;
+import org.hibernate.bytecode.BytecodeLogger;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
@@ -49,8 +50,16 @@ public class EnhancementAsProxyLazinessInterceptor extends AbstractLazyLoadInter
 		}
 	}
 
-	protected Object forceInitialize(Object target, String attributeName) {
-		return new Helper( this ).performWork(
+	public Object forceInitialize(Object target, String attributeName) {
+		BytecodeLogger.LOGGER.tracef(
+				"EnhancementAsProxyLazinessInterceptor#forceInitialize : %s#%s -> %s )",
+				entityKey.getEntityName(),
+				entityKey.getIdentifier(),
+				attributeName
+		);
+
+		return Helper.performWork(
+				this,
 				(session, isTemporarySession) -> {
 					final EntityPersister persister = session.getFactory()
 							.getMetamodel()
@@ -113,5 +122,10 @@ public class EnhancementAsProxyLazinessInterceptor extends AbstractLazyLoadInter
 		if ( initialized ) {
 			throw new UnsupportedOperationException( "Expected call to EnhancementAsProxyLazinessInterceptor#attributeInitialized" );
 		}
+	}
+
+	@Override
+	public Object getIdentifier() {
+		return entityKey.getIdentifier();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.bytecode.enhance.spi.interceptor;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.hibernate.LockMode;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.Status;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * @author Steve Ebersole
+ */
+public class EnhancementAsProxyLazinessInterceptor extends AbstractLazyLoadInterceptor {
+	private final EntityKey entityKey;
+
+	private boolean initialized;
+
+	public EnhancementAsProxyLazinessInterceptor(
+			String entityName,
+			EntityKey entityKey,
+			SharedSessionContractImplementor session) {
+		super( entityName, session );
+		this.entityKey = entityKey;
+	}
+
+	public EntityKey getEntityKey() {
+		return entityKey;
+	}
+
+	@Override
+	protected Object handleRead(Object target, String attributeName, Object value) {
+		if ( initialized ) {
+			throw new IllegalStateException( "EnhancementAsProxyLazinessInterceptor interception on an initialized instance" );
+		}
+
+		try {
+			return forceInitialize( target, attributeName );
+		}
+		finally {
+			initialized = true;
+		}
+	}
+
+	protected Object forceInitialize(Object target, String attributeName) {
+		return new Helper( this ).performWork(
+				(session, isTemporarySession) -> {
+					final EntityPersister persister = session.getFactory()
+							.getMetamodel()
+							.entityPersister( getEntityName() );
+
+					if ( isTemporarySession ) {
+						// Add an entry for this entity in the PC of the temp Session
+						// NOTE : a few arguments that would be nice to pass along here...
+						//		1) loadedState if we know any
+						final Object[] loadedState = null;
+						//		2) does a row exist in the db for this entity?
+						final boolean existsInDb = true;
+						session.getPersistenceContext().addEntity(
+								target,
+								Status.READ_ONLY,
+								loadedState,
+								entityKey,
+								persister.getVersion( target ),
+								LockMode.NONE,
+								existsInDb,
+								persister,
+								true
+						);
+					}
+
+					return persister.initializeEnhancedEntityUsedAsProxy(
+							target,
+							attributeName,
+							session
+					);
+				},
+				getEntityName(),
+				attributeName
+		);
+	}
+
+	@Override
+	protected Object handleWrite(Object target, String attributeName, Object oldValue, Object newValue) {
+		if ( initialized ) {
+			throw new IllegalStateException( "EnhancementAsProxyLazinessInterceptor interception on an initialized instance" );
+		}
+
+		try {
+			forceInitialize( target, attributeName );
+		}
+		finally {
+			initialized = true;
+		}
+
+		return newValue;
+	}
+
+	@Override
+	public Set<String> getInitializedLazyAttributeNames() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public void attributeInitialized(String name) {
+		if ( initialized ) {
+			throw new UnsupportedOperationException( "Expected call to EnhancementAsProxyLazinessInterceptor#attributeInitialized" );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/Helper.java
@@ -15,6 +15,7 @@ import org.hibernate.bytecode.BytecodeLogger;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.SessionFactoryRegistry;
+import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
@@ -49,10 +50,14 @@ public class Helper {
 			final ToOne toOne = (ToOne) value;
 			if ( toOne.isLazy() ) {
 				if ( toOne.isUnwrapProxy() ) {
+					if ( toOne instanceof OneToOne ) {
+						return false;
+					}
 					// include it in the base fetch group so long as the config allows
 					// using the FK to create an "enhancement proxy"
 					return allowEnhancementAsProxy;
 				}
+
 			}
 
 			return true;

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -28,15 +28,23 @@ import org.hibernate.persister.entity.EntityPersister;
  * @author Steve Ebersole
  */
 public class LazyAttributeLoadingInterceptor extends AbstractLazyLoadInterceptor {
+	private final Object identifier;
 	private final Set<String> lazyFields;
 	private Set<String> initializedLazyFields;
 
 	public LazyAttributeLoadingInterceptor(
 			String entityName,
+			Object identifier,
 			Set<String> lazyFields,
 			SharedSessionContractImplementor session) {
 		super( entityName, session );
+		this.identifier = identifier;
 		this.lazyFields = lazyFields;
+	}
+
+	@Override
+	public Object getIdentifier() {
+		return identifier;
 	}
 
 	@Override
@@ -66,7 +74,8 @@ public class LazyAttributeLoadingInterceptor extends AbstractLazyLoadInterceptor
 	}
 
 	protected Object loadAttribute(final Object target, final String attributeName) {
-		return new Helper( this ).performWork(
+		return Helper.performWork(
+				this,
 				(session, isTemporarySession) -> {
 					final EntityPersister persister = session.getFactory().getMetamodel().entityPersister( getEntityName() );
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -60,7 +60,6 @@ public class LazyAttributeLoadingInterceptor extends AbstractLazyLoadInterceptor
 	@Override
 	protected Object handleWrite(Object target, String attributeName, Object oldValue, Object newValue) {
 		if ( !isAttributeLoaded( attributeName ) ) {
-			fetchAttribute( target, attributeName );
 			attributeInitialized( attributeName );
 		}
 		return newValue;

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -16,16 +16,10 @@ import java.util.Set;
 import org.hibernate.LockMode;
 import org.hibernate.bytecode.enhance.spi.CollectionTracker;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
-import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer.InterceptorImplementor;
-import org.hibernate.bytecode.enhance.spi.interceptor.Helper.Consumer;
-import org.hibernate.bytecode.enhance.spi.interceptor.Helper.LazyInitializationWork;
-import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.persister.entity.EntityPersister;
-
-import org.jboss.logging.Logger;
 
 /**
  * Interceptor that loads attributes lazily
@@ -33,36 +27,35 @@ import org.jboss.logging.Logger;
  * @author Luis Barreiro
  * @author Steve Ebersole
  */
-public class LazyAttributeLoadingInterceptor
-		implements PersistentAttributeInterceptor, Consumer, InterceptorImplementor {
-	private static final Logger log = Logger.getLogger( LazyAttributeLoadingInterceptor.class );
-
-	private final String entityName;
+public class LazyAttributeLoadingInterceptor extends AbstractLazyLoadInterceptor {
 	private final Set<String> lazyFields;
-
 	private Set<String> initializedLazyFields;
-
-	private transient SharedSessionContractImplementor session;
-	private boolean allowLoadOutsideTransaction;
-	private String sessionFactoryUuid;
 
 	public LazyAttributeLoadingInterceptor(
 			String entityName,
 			Set<String> lazyFields,
 			SharedSessionContractImplementor session) {
-		this.entityName = entityName;
+		super( entityName, session );
 		this.lazyFields = lazyFields;
-
-		setSession( session );
 	}
 
-	protected final Object intercept(Object target, String attributeName, Object value) {
+	@Override
+	protected Object handleRead(Object target, String attributeName, Object value) {
 		if ( !isAttributeLoaded( attributeName ) ) {
 			Object loadedValue = fetchAttribute( target, attributeName );
 			attributeInitialized( attributeName );
 			return loadedValue;
 		}
 		return value;
+	}
+
+	@Override
+	protected Object handleWrite(Object target, String attributeName, Object oldValue, Object newValue) {
+		if ( !isAttributeLoaded( attributeName ) ) {
+			fetchAttribute( target, attributeName );
+			attributeInitialized( attributeName );
+		}
+		return newValue;
 	}
 
 	/**
@@ -74,69 +67,44 @@ public class LazyAttributeLoadingInterceptor
 
 	protected Object loadAttribute(final Object target, final String attributeName) {
 		return new Helper( this ).performWork(
-				new LazyInitializationWork() {
-					@Override
-					public Object doWork(SharedSessionContractImplementor session, boolean isTemporarySession) {
-						final EntityPersister persister = session.getFactory().getMetamodel().entityPersister( getEntityName() );
+				(session, isTemporarySession) -> {
+					final EntityPersister persister = session.getFactory().getMetamodel().entityPersister( getEntityName() );
 
-						if ( isTemporarySession ) {
-							final Serializable id = persister.getIdentifier( target, null );
+					if ( isTemporarySession ) {
+						final Serializable id = persister.getIdentifier( target, null );
 
-							// Add an entry for this entity in the PC of the temp Session
-							// NOTE : a few arguments that would be nice to pass along here...
-							//		1) loadedState if we know any
-							final Object[] loadedState = null;
-							//		2) does a row exist in the db for this entity?
-							final boolean existsInDb = true;
-							session.getPersistenceContext().addEntity(
-									target,
-									Status.READ_ONLY,
-									loadedState,
-									session.generateEntityKey( id, persister ),
-									persister.getVersion( target ),
-									LockMode.NONE,
-									existsInDb,
-									persister,
-									true
-							);
-						}
-
-						final LazyPropertyInitializer initializer = (LazyPropertyInitializer) persister;
-						final Object loadedValue = initializer.initializeLazyProperty(
-								attributeName,
+						// Add an entry for this entity in the PC of the temp Session
+						// NOTE : a few arguments that would be nice to pass along here...
+						//		1) loadedState if we know any
+						final Object[] loadedState = null;
+						//		2) does a row exist in the db for this entity?
+						final boolean existsInDb = true;
+						session.getPersistenceContext().addEntity(
 								target,
-								session
+								Status.READ_ONLY,
+								loadedState,
+								session.generateEntityKey( id, persister ),
+								persister.getVersion( target ),
+								LockMode.NONE,
+								existsInDb,
+								persister,
+								true
 						);
-
-						takeCollectionSizeSnapshot( target, attributeName, loadedValue );
-						return loadedValue;
 					}
 
-					@Override
-					public String getEntityName() {
-						return entityName;
-					}
+					final LazyPropertyInitializer initializer = (LazyPropertyInitializer) persister;
+					final Object loadedValue = initializer.initializeLazyProperty(
+							attributeName,
+							target,
+							session
+					);
 
-					@Override
-					public String getAttributeName() {
-						return attributeName;
-					}
-				}
+					takeCollectionSizeSnapshot( target, attributeName, loadedValue );
+					return loadedValue;
+				},
+				getEntityName(),
+				attributeName
 		);
-	}
-
-	public final void setSession(SharedSessionContractImplementor session) {
-		this.session = session;
-		if ( session != null && !allowLoadOutsideTransaction ) {
-			this.allowLoadOutsideTransaction = session.getFactory().getSessionFactoryOptions().isInitializeLazyStateOutsideTransactionsEnabled();
-			if ( this.allowLoadOutsideTransaction ) {
-				this.sessionFactoryUuid = session.getFactory().getUuid();
-			}
-		}
-	}
-
-	public final void unsetSession() {
-		this.session = null;
 	}
 
 	public boolean isAttributeLoaded(String fieldName) {
@@ -171,13 +139,11 @@ public class LazyAttributeLoadingInterceptor
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + "(entityName=" + entityName + " ,lazyFields=" + lazyFields + ')';
+		return getClass().getSimpleName() + "(entityName=" + getEntityName() + " ,lazyFields=" + lazyFields + ')';
 	}
 
-	//
-
 	private void takeCollectionSizeSnapshot(Object target, String fieldName, Object value) {
-		if ( value != null && value instanceof Collection && target instanceof SelfDirtinessTracker ) {
+		if ( value instanceof Collection && target instanceof SelfDirtinessTracker ) {
 			CollectionTracker tracker = ( (SelfDirtinessTracker) target ).$$_hibernate_getCollectionTracker();
 			if ( tracker == null ) {
 				( (SelfDirtinessTracker) target ).$$_hibernate_clearDirtyAttributes();
@@ -188,151 +154,19 @@ public class LazyAttributeLoadingInterceptor
 	}
 
 	@Override
-	public boolean readBoolean(Object obj, String name, boolean oldValue) {
-		return (Boolean) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public boolean writeBoolean(Object obj, String name, boolean oldValue, boolean newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public byte readByte(Object obj, String name, byte oldValue) {
-		return (Byte) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public byte writeByte(Object obj, String name, byte oldValue, byte newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public char readChar(Object obj, String name, char oldValue) {
-		return (Character) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public char writeChar(Object obj, String name, char oldValue, char newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public short readShort(Object obj, String name, short oldValue) {
-		return (Short) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public short writeShort(Object obj, String name, short oldValue, short newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public int readInt(Object obj, String name, int oldValue) {
-		return (Integer) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public int writeInt(Object obj, String name, int oldValue, int newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public float readFloat(Object obj, String name, float oldValue) {
-		return (Float) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public float writeFloat(Object obj, String name, float oldValue, float newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public double readDouble(Object obj, String name, double oldValue) {
-		return (Double) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public double writeDouble(Object obj, String name, double oldValue, double newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public long readLong(Object obj, String name, long oldValue) {
-		return (Long) intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public long writeLong(Object obj, String name, long oldValue, long newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public Object readObject(Object obj, String name, Object oldValue) {
-		return intercept( obj, name, oldValue );
-	}
-
-	@Override
-	public Object writeObject(Object obj, String name, Object oldValue, Object newValue) {
-		if ( lazyFields != null && lazyFields.contains( name ) ) {
-			attributeInitialized( name );
-		}
-		return newValue;
-	}
-
-	@Override
-	public SharedSessionContractImplementor getLinkedSession() {
-		return session;
-	}
-
-	@Override
-	public boolean allowLoadOutsideTransaction() {
-		return allowLoadOutsideTransaction;
-	}
-
-	@Override
-	public String getSessionFactoryUuid() {
-		return sessionFactoryUuid;
-	}
-
-	@Override
 	public void attributeInitialized(String name) {
 		if ( !isLazyAttribute( name ) ) {
 			return;
 		}
 		if ( initializedLazyFields == null ) {
-			initializedLazyFields = new HashSet<String>();
+			initializedLazyFields = new HashSet<>();
 		}
 		initializedLazyFields.add( name );
 	}
 
 	@Override
 	public Set<String> getInitializedLazyAttributeNames() {
-		return initializedLazyFields == null ? Collections.<String>emptySet() : initializedLazyFields;
+		return initializedLazyFields == null ? Collections.emptySet() : initializedLazyFields;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
@@ -44,6 +44,7 @@ public class LazyAttributesMetadata implements Serializable {
 		while ( itr.hasNext() ) {
 			i++;
 			final Property property = (Property) itr.next();
+			// here we want to know lazy just in terms of Property's local `#lazy` marker
 			if ( property.isLazy() ) {
 				final LazyAttributeDescriptor lazyAttributeDescriptor = LazyAttributeDescriptor.from( property, i, x++ );
 				lazyAttributeDescriptorMap.put( lazyAttributeDescriptor.getName(), lazyAttributeDescriptor );

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
@@ -29,12 +29,11 @@ public class LazyAttributesMetadata implements Serializable {
 	/**
 	 * Build a LazyFetchGroupMetadata based on the attributes defined for the
 	 * PersistentClass
-	 *
-	 * @param mappedEntity The entity definition
-	 *
-	 * @return The built LazyFetchGroupMetadata
 	 */
-	public static LazyAttributesMetadata from(PersistentClass mappedEntity) {
+	public static LazyAttributesMetadata from(
+			PersistentClass mappedEntity,
+			boolean isEnhanced,
+			boolean allowEnhancementAsProxy) {
 		final Map<String, LazyAttributeDescriptor> lazyAttributeDescriptorMap = new LinkedHashMap<>();
 		final Map<String, Set<String>> fetchGroupToAttributesMap = new HashMap<>();
 
@@ -44,8 +43,8 @@ public class LazyAttributesMetadata implements Serializable {
 		while ( itr.hasNext() ) {
 			i++;
 			final Property property = (Property) itr.next();
-			// here we want to know lazy just in terms of Property's local `#lazy` marker
-			if ( property.isLazy() ) {
+			final boolean lazy = ! Helper.includeInBaseFetchGroup( property, isEnhanced, allowEnhancementAsProxy );
+			if ( lazy ) {
 				final LazyAttributeDescriptor lazyAttributeDescriptor = LazyAttributeDescriptor.from( property, i, x++ );
 				lazyAttributeDescriptorMap.put( lazyAttributeDescriptor.getName(), lazyAttributeDescriptor );
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/SessionAssociableInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/SessionAssociableInterceptor.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.bytecode.enhance.spi.interceptor;
+
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface SessionAssociableInterceptor extends PersistentAttributeInterceptor {
+	SharedSessionContractImplementor getLinkedSession();
+
+	void setSession(SharedSessionContractImplementor session);
+
+	void unsetSession();
+
+	boolean allowLoadOutsideTransaction();
+
+	String getSessionFactoryUuid();
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeEnhancementMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeEnhancementMetadata.java
@@ -7,7 +7,6 @@
 package org.hibernate.bytecode.spi;
 
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
-import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
 import org.hibernate.engine.spi.EntityKey;
@@ -41,6 +40,7 @@ public interface BytecodeEnhancementMetadata {
 	 * Build and inject an interceptor instance into the enhanced entity.
 	 *
 	 * @param entity The entity into which built interceptor should be injected
+	 * @param identifier
 	 * @param session The session to which the entity instance belongs.
 	 *
 	 * @return The built and injected interceptor
@@ -49,7 +49,13 @@ public interface BytecodeEnhancementMetadata {
 	 */
 	LazyAttributeLoadingInterceptor injectInterceptor(
 			Object entity,
+			Object identifier,
 			SharedSessionContractImplementor session) throws NotInstrumentedException;
+
+	void injectInterceptor(
+			Object entity,
+			PersistentAttributeInterceptor interceptor,
+			SharedSessionContractImplementor session);
 
 	void injectEnhancedEntityAsProxyInterceptor(
 			Object entity,

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeEnhancementMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeEnhancementMetadata.java
@@ -6,8 +6,12 @@
  */
 package org.hibernate.bytecode.spi;
 
+import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
+import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -47,6 +51,11 @@ public interface BytecodeEnhancementMetadata {
 			Object entity,
 			SharedSessionContractImplementor session) throws NotInstrumentedException;
 
+	void injectEnhancedEntityAsProxyInterceptor(
+			Object entity,
+			EntityKey entityKey,
+			SharedSessionContractImplementor session);
+
 	/**
 	 * Extract the field interceptor instance from the enhanced entity.
 	 *
@@ -57,6 +66,8 @@ public interface BytecodeEnhancementMetadata {
 	 * @throws NotInstrumentedException Thrown if {@link #isEnhancedForLazyLoading()} returns {@code false}
 	 */
 	LazyAttributeLoadingInterceptor extractInterceptor(Object entity) throws NotInstrumentedException;
+
+	BytecodeLazyAttributeInterceptor extractLazyInterceptor(Object entity) throws NotInstrumentedException;
 
 	boolean hasUnFetchedAttributes(Object entity);
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -868,6 +868,27 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	String ENFORCE_LEGACY_PROXY_CLASSNAMES = "hibernate.bytecode.enforce_legacy_proxy_classnames";
 
 	/**
+	 * Should Hibernate use enhanced entities "as a proxy"?
+	 *
+	 * E.g., when an application uses {@link org.hibernate.Session#load} against an enhanced
+	 * class, enabling this will allow Hibernate to create an "empty" instance of the enhanced
+	 * class to act as the proxy - it contains just the identifier which is later used to
+	 * trigger the base initialization but no other data is loaded
+	 *
+	 * Not enabling this (the legacy default behavior) would cause the "base" attributes to
+	 * be loaded.  Any lazy-group attributes would not be initialized.
+	 *
+	 * Applications using bytecode enhancement and switching to allowing this should be careful
+	 * in use of the various {@link org.hibernate.Hibernate} methods such as
+	 * {@link org.hibernate.Hibernate#isInitialized},
+	 * {@link org.hibernate.Hibernate#isPropertyInitialized}, etc - enabling this setting changes
+	 * the results of those methods
+	 *
+	 * @implSpec See {@link org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor}
+	 */
+	String ALLOW_ENHANCEMENT_AS_PPROXY = "hibernate.bytecode.allow_enhancement_as_proxy";
+
+	/**
 	 * The classname of the HQL query parser factory
 	 */
 	String QUERY_TRANSLATOR = "hibernate.query.factory_class";

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistentAttributeInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistentAttributeInterceptor.java
@@ -6,48 +6,76 @@
  */
 package org.hibernate.engine.spi;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.hibernate.Incubating;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer.InterceptorImplementor;
+import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 
 /**
+ * The base contract for interceptors that can be injected into
+ * enhanced entities for the purpose of intercepting attribute access
+ *
  * @author Steve Ebersole
+ *
+ * @see PersistentAttributeInterceptable
  */
 @Incubating
+@SuppressWarnings("unused")
 public interface PersistentAttributeInterceptor extends InterceptorImplementor {
-	public boolean readBoolean(Object obj, String name, boolean oldValue);
+	boolean readBoolean(Object obj, String name, boolean oldValue);
 
-	public boolean writeBoolean(Object obj, String name, boolean oldValue, boolean newValue);
+	boolean writeBoolean(Object obj, String name, boolean oldValue, boolean newValue);
 
-	public byte readByte(Object obj, String name, byte oldValue);
+	byte readByte(Object obj, String name, byte oldValue);
 
-	public byte writeByte(Object obj, String name, byte oldValue, byte newValue);
+	byte writeByte(Object obj, String name, byte oldValue, byte newValue);
 
-	public char readChar(Object obj, String name, char oldValue);
+	char readChar(Object obj, String name, char oldValue);
 
-	public char writeChar(Object obj, String name, char oldValue, char newValue);
+	char writeChar(Object obj, String name, char oldValue, char newValue);
 
-	public short readShort(Object obj, String name, short oldValue);
+	short readShort(Object obj, String name, short oldValue);
 
-	public short writeShort(Object obj, String name, short oldValue, short newValue);
+	short writeShort(Object obj, String name, short oldValue, short newValue);
 
-	public int readInt(Object obj, String name, int oldValue);
+	int readInt(Object obj, String name, int oldValue);
 
-	public int writeInt(Object obj, String name, int oldValue, int newValue);
+	int writeInt(Object obj, String name, int oldValue, int newValue);
 
-	public float readFloat(Object obj, String name, float oldValue);
+	float readFloat(Object obj, String name, float oldValue);
 
-	public float writeFloat(Object obj, String name, float oldValue, float newValue);
+	float writeFloat(Object obj, String name, float oldValue, float newValue);
 
-	public double readDouble(Object obj, String name, double oldValue);
+	double readDouble(Object obj, String name, double oldValue);
 
-	public double writeDouble(Object obj, String name, double oldValue, double newValue);
+	double writeDouble(Object obj, String name, double oldValue, double newValue);
 
-	public long readLong(Object obj, String name, long oldValue);
+	long readLong(Object obj, String name, long oldValue);
 
-	public long writeLong(Object obj, String name, long oldValue, long newValue);
+	long writeLong(Object obj, String name, long oldValue, long newValue);
 
-	public Object readObject(Object obj, String name, Object oldValue);
+	Object readObject(Object obj, String name, Object oldValue);
 
-	public Object writeObject(Object obj, String name, Object oldValue, Object newValue);
+	Object writeObject(Object obj, String name, Object oldValue, Object newValue);
 
+	/**
+	 * @deprecated Just as the method it overrides.  Interceptors that deal with
+	 * lazy state should implement {@link BytecodeLazyAttributeInterceptor}
+	 */
+	@Deprecated
+	@Override
+	default Set<String> getInitializedLazyAttributeNames() {
+		return Collections.emptySet();
+	}
+
+	/**
+	 * @deprecated Just as the method it overrides.  Interceptors that deal with
+	 * lazy state should implement {@link BytecodeLazyAttributeInterceptor}
+	 */
+	@Override
+	@Deprecated
+	default void attributeInitialized(String name) {
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistentAttributeInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistentAttributeInterceptor.java
@@ -6,13 +6,14 @@
  */
 package org.hibernate.engine.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer.InterceptorImplementor;
 
 /**
  * @author Steve Ebersole
  */
+@Incubating
 public interface PersistentAttributeInterceptor extends InterceptorImplementor {
-
 	public boolean readBoolean(Object obj, String name, boolean oldValue);
 
 	public boolean writeBoolean(Object obj, String name, boolean oldValue, boolean newValue);

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -246,6 +246,15 @@ public interface SharedSessionContractImplementor
 	Object internalLoad(String entityName, Serializable id, boolean eager, boolean nullable)
 			throws HibernateException;
 
+	default Object internalLoad(
+			String entityName,
+			Serializable id,
+			boolean eager,
+			boolean nullable,
+			Boolean unwrapProxy) throws HibernateException {
+		return internalLoad( entityName, id, eager, nullable );
+	}
+
 	/**
 	 * Load an instance immediately. This method is only called when lazily initializing a proxy.
 	 * Do not return the proxy.

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -263,7 +263,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 				return proxy;
 			}
 
-			if ( ! persister.isVersioned() ) {
+			if ( !persister.isVersioned() && !persister.getEntityMetamodel().hasSubclasses() ) {
 				// create the (uninitialized) entity instance - has only id set
 				final Object entity = persister.getEntityTuplizer().instantiate(
 						keyToLoad.getIdentifier(),
@@ -288,6 +288,16 @@ public class DefaultLoadEventListener implements LoadEventListener {
 						.injectEnhancedEntityAsProxyInterceptor( entity, keyToLoad, event.getSession() );
 
 				return entity;
+			}else {
+				if ( proxy != null ) {
+					return returnNarrowedProxy( event, persister, keyToLoad, options, persistenceContext, proxy );
+				}
+
+				if ( options.isAllowProxyCreation()
+						&& !options.isUnwrapProxy()
+				) {
+					return createProxyIfNecessary( event, persister, keyToLoad, options, persistenceContext );
+				}
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -203,7 +203,10 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			persister.setIdentifier( copyCache.get( entity ), id, source );
 		}
 		else {
-			( (MergeContext) copyCache ).put( entity, source.instantiate( persister, id ), true ); //before cascade!
+			final Object copy = source.instantiate( persister, id );
+
+			//before cascade!
+			( (MergeContext) copyCache ).put( entity, copy, true );
 		}
 		final Object copy = copyCache.get( entity );
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -14,12 +14,15 @@ import org.hibernate.HibernateException;
 import org.hibernate.ObjectDeletedException;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.WrongClassException;
+import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.engine.internal.Cascade;
 import org.hibernate.engine.internal.CascadePoint;
 import org.hibernate.engine.spi.CascadingAction;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -98,12 +101,27 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 				if ( li.isUninitialized() ) {
 					LOG.trace( "Ignoring uninitialized proxy" );
 					event.setResult( source.load( li.getEntityName(), li.getIdentifier() ) );
-					return; //EARLY EXIT!
+					//EARLY EXIT!
+					return;
 				}
 				else {
 					entity = li.getImplementation();
 				}
 			}
+//			else if ( original instanceof PersistentAttributeInterceptable ) {
+//				final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) original;
+//				final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
+//				if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
+//					final EnhancementAsProxyLazinessInterceptor proxyInterceptor = (EnhancementAsProxyLazinessInterceptor) interceptor;
+//					LOG.trace( "Ignoring uninitialized proxy" );
+//					event.setResult( source.load( proxyInterceptor.getEntityName(), (Serializable) proxyInterceptor.getIdentifier() ) );
+//					//EARLY EXIT!
+//					return;
+//				}
+//				else {
+//					entity = original;
+//				}
+//			}
 			else {
 				entity = original;
 			}
@@ -208,6 +226,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			//before cascade!
 			( (MergeContext) copyCache ).put( entity, copy, true );
 		}
+
 		final Object copy = copyCache.get( entity );
 
 		// cascade first, so that all unsaved objects get their

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/LoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/LoadEventListener.java
@@ -68,6 +68,27 @@ public interface LoadEventListener extends Serializable {
 			.setCheckDeleted( false )
 			.setNakedEntityReturned( false );
 
+	LoadType INTERNAL_LOAD_EAGER_UNWRAP_PROXY = new LoadType( "INTERNAL_LOAD_EAGER" )
+			.setAllowNulls( false )
+			.setAllowProxyCreation( false )
+			.setCheckDeleted( false )
+			.setNakedEntityReturned( false )
+			.setUnwrapProxy( true );
+
+	LoadType INTERNAL_LOAD_LAZY_UNWRAP_PROXY = new LoadType( "INTERNAL_LOAD_LAZY" )
+			.setAllowNulls( false )
+			.setAllowProxyCreation( true )
+			.setCheckDeleted( false )
+			.setNakedEntityReturned( false )
+			.setUnwrapProxy( true );
+
+	LoadType INTERNAL_LOAD_NULLABLE_UNWRAP_PROXY = new LoadType( "INTERNAL_LOAD_NULLABLE" )
+			.setAllowNulls( true )
+			.setAllowProxyCreation( false )
+			.setCheckDeleted( false )
+			.setNakedEntityReturned( false )
+			.setUnwrapProxy( true );
+
 	public static final class LoadType {
 		private String name;
 
@@ -133,8 +154,9 @@ public interface LoadEventListener extends Serializable {
 			return isUnwrapProxy;
 		}
 
-		public void setUnwrapProxy(Boolean unwrapProxy) {
+		public LoadType setUnwrapProxy(Boolean unwrapProxy) {
 			isUnwrapProxy = unwrapProxy;
+			return this;
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/LoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/LoadEventListener.java
@@ -75,6 +75,7 @@ public interface LoadEventListener extends Serializable {
 		private boolean allowNulls;
 		private boolean checkDeleted;
 		private boolean allowProxyCreation;
+		private Boolean isUnwrapProxy;
 
 		private LoadType(String name) {
 			this.name = name;
@@ -123,6 +124,17 @@ public interface LoadEventListener extends Serializable {
 		@Override
 		public String toString() {
 			return name;
+		}
+
+		public boolean isUnwrapProxy() {
+			if ( isUnwrapProxy == null ) {
+				return !isAllowProxyCreation();
+			}
+			return isUnwrapProxy;
+		}
+
+		public void setUnwrapProxy(Boolean unwrapProxy) {
+			isUnwrapProxy = unwrapProxy;
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1129,11 +1129,18 @@ public final class SessionImpl
 	}
 
 	@Override
+	public final Object internalLoad(String entityName, Serializable id, boolean eager, boolean nullable)
+			throws HibernateException {
+		return internalLoad( entityName, id, eager, nullable, null );
+	}
+
+	@Override
 	public final Object internalLoad(
 			String entityName,
 			Serializable id,
 			boolean eager,
-			boolean nullable) throws HibernateException {
+			boolean nullable,
+			Boolean unwrapProxy) throws HibernateException {
 
 		final EffectiveEntityGraph effectiveEntityGraph = getLoadQueryInfluencers().getEffectiveEntityGraph();
 		final GraphSemantic semantic = effectiveEntityGraph.getSemantic();
@@ -1157,6 +1164,8 @@ public final class SessionImpl
 						? LoadEventListener.INTERNAL_LOAD_EAGER
 						: LoadEventListener.INTERNAL_LOAD_LAZY;
 			}
+
+			type.setUnwrapProxy( unwrapProxy );
 
 			LoadEvent event = loadEvent;
 			loadEvent = null;

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1157,12 +1157,25 @@ public final class SessionImpl
 		try {
 			final LoadEventListener.LoadType type;
 			if ( nullable ) {
-				type = LoadEventListener.INTERNAL_LOAD_NULLABLE;
+				if ( unwrapProxy ) {
+					type = LoadEventListener.INTERNAL_LOAD_NULLABLE_UNWRAP_PROXY;
+
+				}
+				else {
+					type = LoadEventListener.INTERNAL_LOAD_NULLABLE;
+				}
 			}
 			else {
-				type = eager
-						? LoadEventListener.INTERNAL_LOAD_EAGER
-						: LoadEventListener.INTERNAL_LOAD_LAZY;
+				if ( unwrapProxy ) {
+					type = eager
+							? LoadEventListener.INTERNAL_LOAD_EAGER_UNWRAP_PROXY
+							: LoadEventListener.INTERNAL_LOAD_LAZY_UNWRAP_PROXY;
+				}
+				else {
+					type = eager
+							? LoadEventListener.INTERNAL_LOAD_EAGER
+							: LoadEventListener.INTERNAL_LOAD_LAZY;
+				}
 			}
 
 			type.setUnwrapProxy( unwrapProxy );

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/EntityReferenceInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/EntityReferenceInitializerImpl.java
@@ -14,6 +14,10 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.WrongClassException;
+import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
+import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
+import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.engine.internal.TwoPhaseLoad;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.EntityKey;
@@ -195,7 +199,22 @@ public class EntityReferenceInitializerImpl implements EntityReferenceInitialize
 			// use the existing association as the hydrated state
 			processingState.registerEntityInstance( existing );
 			//context.registerHydratedEntity( entityReference, entityKey, existing );
-			return;
+
+			boolean readFromResults = false;
+			// see if the entity is enhanced and is being used as a "proxy" (is fully uninitialized)
+			final BytecodeEnhancementMetadata enhancementMetadata = entityReference.getEntityPersister()
+					.getEntityMetamodel()
+					.getBytecodeEnhancementMetadata();
+			if ( enhancementMetadata.isEnhancedForLazyLoading() ) {
+				final BytecodeLazyAttributeInterceptor interceptor = enhancementMetadata.extractLazyInterceptor( existing );
+				if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
+					readFromResults = true;
+				}
+			}
+
+			if ( ! readFromResults ) {
+				return;
+			}
 		}
 
 		// Otherwise, we need to load it from the ResultSet...

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -253,8 +253,10 @@ public class Property implements Serializable, MetaAttributable {
 			// groupings.  If that assertion changes then this check
 			// needs to change as well.  Partially, this is an issue with
 			// the overloading of the term "lazy" here...
-			ToOne toOneValue = ( ToOne ) value;
-			return toOneValue.isLazy() && toOneValue.isUnwrapProxy();
+//			ToOne toOneValue = ( ToOne ) value;
+//			return toOneValue.isLazy() && toOneValue.isUnwrapProxy();
+
+			return false;
 		}
 		return lazy;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -14,6 +14,8 @@ import org.hibernate.EntityMode;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.PropertyNotFoundException;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.bytecode.enhance.spi.interceptor.Helper;
 import org.hibernate.engine.spi.CascadeStyle;
 import org.hibernate.engine.spi.CascadeStyles;
 import org.hibernate.engine.spi.Mapping;
@@ -233,31 +235,31 @@ public class Property implements Serializable, MetaAttributable {
 	public void setLazy(boolean lazy) {
 		this.lazy=lazy;
 	}
-	
+
+	/**
+	 * Is this property lazy in the "bytecode" sense?
+	 *
+	 * Lazy here means whether we should push *something* to the entity
+	 * instance for this field in its "base fetch group".  Mainly it affects
+	 * whether we should list this property's columns in the SQL select
+	 * for the owning entity when we load its "base fetch group".
+	 *
+	 * The "something" we push varies based on the nature (basic, etc) of
+	 * the property.
+	 *
+	 * @apiNote This form reports whether the property is considered part of the
+	 * base fetch group based solely on the mapping information.  However,
+	 * {@link Helper#includeInBaseFetchGroup} is used internally to make that
+	 * decision to account for {@link org.hibernate.cfg.AvailableSettings#ALLOW_ENHANCEMENT_AS_PPROXY}
+	 */
 	public boolean isLazy() {
 		if ( value instanceof ToOne ) {
-			// both many-to-one and one-to-one are represented as a
-			// Property.  EntityPersister is relying on this value to
-			// determine "lazy fetch groups" in terms of field-level
-			// interception.  So we need to make sure that we return
-			// true here for the case of many-to-one and one-to-one
-			// with lazy="no-proxy"
-			//
-			// * impl note - lazy="no-proxy" currently forces both
-			// lazy and unwrap to be set to true.  The other case we
-			// are extremely interested in here is that of lazy="proxy"
-			// where lazy is set to true, but unwrap is set to false.
-			// thus we use both here under the assumption that this
-			// return is really only ever used during persister
-			// construction to determine the lazy property/field fetch
-			// groupings.  If that assertion changes then this check
-			// needs to change as well.  Partially, this is an issue with
-			// the overloading of the term "lazy" here...
-//			ToOne toOneValue = ( ToOne ) value;
-//			return toOneValue.isLazy() && toOneValue.isUnwrapProxy();
-
+			// For a many-to-one, this is always false.  Whether the
+			// association is EAGER, PROXY or NO-PROXY we want the fk
+			// selected
 			return false;
 		}
+
 		return lazy;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -77,6 +77,7 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.PersistenceContext.NaturalIdHelper;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.ValueInclusion;
@@ -1039,7 +1040,7 @@ public abstract class AbstractEntityPersister
 
 	public Object initializeLazyProperty(String fieldName, Object entity, SharedSessionContractImplementor session) {
 		final EntityEntry entry = session.getPersistenceContext().getEntry( entity );
-		final InterceptorImplementor interceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
+		final PersistentAttributeInterceptor interceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
 		assert interceptor != null : "Expecting bytecode interceptor to be non-null";
 
 		if ( hasCollections() ) {
@@ -1160,7 +1161,7 @@ public abstract class AbstractEntityPersister
 			throw new AssertionFailure( "no lazy properties" );
 		}
 
-		final InterceptorImplementor interceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
+		final PersistentAttributeInterceptor interceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
 		assert interceptor != null : "Expecting bytecode interceptor to be non-null";
 
 		LOG.trace( "Initializing lazy properties from datastore" );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -15,7 +15,9 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
+import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
+import org.hibernate.bytecode.spi.NotInstrumentedException;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.cache.spi.entry.CacheEntry;
@@ -131,6 +133,20 @@ public interface EntityPersister extends EntityDefinition {
 	 *@return The metamodel
 	 */
 	EntityMetamodel getEntityMetamodel();
+
+	/**
+	 * Called from {@link EnhancementAsProxyLazinessInterceptor} to trigger load of
+	 * the entity's non-lazy state as well as the named attribute we are accessing
+	 * if it is still uninitialized after fetching non-lazy state
+	 */
+	default Object initializeEnhancedEntityUsedAsProxy(
+			Object entity,
+			String nameOfAttributeBeingAccessed,
+			SharedSessionContractImplementor session) {
+		throw new UnsupportedOperationException(
+				"Initialization of entity enhancement used to act like a proxy is not supported by this EntityPersister : " + getClass().getName()
+		);
+	}
 
 	/**
 	 * Determine whether the given name represents a subclass entity

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
@@ -153,7 +153,7 @@ public abstract class AbstractEntityTuplizer implements EntityTuplizer {
 
 		instantiator = buildInstantiator( entityMetamodel, mappingInfo );
 
-		if ( entityMetamodel.isLazy() && !entityMetamodel.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading() ) {
+		if ( entityMetamodel.isLazy() ) {
 			proxyFactory = buildProxyFactory( mappingInfo, idGetter, idSetter );
 			if ( proxyFactory == null ) {
 				entityMetamodel.setLazy( false );

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataNonPojoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataNonPojoImpl.java
@@ -12,6 +12,7 @@ import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.bytecode.spi.NotInstrumentedException;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -46,7 +47,16 @@ public class BytecodeEnhancementMetadataNonPojoImpl implements BytecodeEnhanceme
 	@Override
 	public LazyAttributeLoadingInterceptor injectInterceptor(
 			Object entity,
+			Object identifier,
 			SharedSessionContractImplementor session) throws NotInstrumentedException {
+		throw new NotInstrumentedException( errorMsg );
+	}
+
+	@Override
+	public void injectInterceptor(
+			Object entity,
+			PersistentAttributeInterceptor interceptor,
+			SharedSessionContractImplementor session) {
 		throw new NotInstrumentedException( errorMsg );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataNonPojoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataNonPojoImpl.java
@@ -6,10 +6,12 @@
  */
 package org.hibernate.tuple.entity;
 
+import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.bytecode.spi.NotInstrumentedException;
+import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -49,7 +51,20 @@ public class BytecodeEnhancementMetadataNonPojoImpl implements BytecodeEnhanceme
 	}
 
 	@Override
+	public void injectEnhancedEntityAsProxyInterceptor(
+			Object entity,
+			EntityKey entityKey,
+			SharedSessionContractImplementor session) {
+		throw new NotInstrumentedException( errorMsg );
+	}
+
+	@Override
 	public LazyAttributeLoadingInterceptor extractInterceptor(Object entity) throws NotInstrumentedException {
+		throw new NotInstrumentedException( errorMsg );
+	}
+
+	@Override
+	public BytecodeLazyAttributeInterceptor extractLazyInterceptor(Object entity) throws NotInstrumentedException {
 		throw new NotInstrumentedException( errorMsg );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataPojoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataPojoImpl.java
@@ -85,6 +85,7 @@ public class BytecodeEnhancementMetadataPojoImpl implements BytecodeEnhancementM
 			return ( (LazyAttributeLoadingInterceptor) interceptor ).hasAnyUninitializedAttributes();
 		}
 
+		//noinspection RedundantIfStatement
 		if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
 			return true;
 		}
@@ -104,7 +105,6 @@ public class BytecodeEnhancementMetadataPojoImpl implements BytecodeEnhancementM
 		}
 
 		return true;
-//		return false;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityInstantiator.java
@@ -46,6 +46,7 @@ public class PojoEntityInstantiator extends PojoInstantiator {
 
 		PersistentAttributeInterceptor interceptor = new LazyAttributeLoadingInterceptor(
 				entityMetamodel.getName(),
+				null,
 				entityMetamodel.getBytecodeEnhancementMetadata()
 						.getLazyAttributesMetadata()
 						.getLazyAttributeNames(),

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -18,7 +18,6 @@ import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
-import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
 import org.hibernate.classic.Lifecycle;
@@ -273,7 +272,11 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 		if ( entity instanceof PersistentAttributeInterceptable ) {
 			final BytecodeLazyAttributeInterceptor interceptor = getEntityMetamodel().getBytecodeEnhancementMetadata().extractLazyInterceptor( entity );
 			if ( interceptor == null || interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
-				getEntityMetamodel().getBytecodeEnhancementMetadata().injectInterceptor( entity, session );
+				getEntityMetamodel().getBytecodeEnhancementMetadata().injectInterceptor(
+						entity,
+						getIdentifier( entity, session ),
+						session
+				);
 			}
 			else {
 				if ( interceptor.getLinkedSession() == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -16,6 +16,8 @@ import org.hibernate.EntityMode;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
+import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
@@ -268,21 +270,9 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 
 	@Override
 	public void afterInitialize(Object entity, SharedSessionContractImplementor session) {
-
-		// moving to multiple fetch groups, the idea of `lazyPropertiesAreUnfetched` really
-		// needs to become either:
-		// 		1) the names of all un-fetched fetch groups
-		//		2) the names of all fetched fetch groups
-		// probably (2) is best
-		//
-		// ultimately this comes from EntityEntry, although usage-search seems to show it is never updated there.
-		//
-		// also org.hibernate.persister.entity.AbstractEntityPersister.initializeLazyPropertiesFromDatastore()
-		//		needs to be re-worked
-
 		if ( entity instanceof PersistentAttributeInterceptable ) {
-			final LazyAttributeLoadingInterceptor interceptor = getEntityMetamodel().getBytecodeEnhancementMetadata().extractInterceptor( entity );
-			if ( interceptor == null ) {
+			final BytecodeLazyAttributeInterceptor interceptor = getEntityMetamodel().getBytecodeEnhancementMetadata().extractLazyInterceptor( entity );
+			if ( interceptor == null || interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
 				getEntityMetamodel().getBytecodeEnhancementMetadata().injectInterceptor( entity, session );
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
@@ -688,7 +688,8 @@ public abstract class EntityType extends AbstractType implements AssociationType
 				getAssociatedEntityName(),
 				id,
 				eager,
-				isNullable()
+				isNullable(),
+				new Boolean( unwrapProxy )
 		);
 
 		if ( proxyOrEntity instanceof HibernateProxy ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/basic/BasicEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/basic/BasicEnhancementTest.java
@@ -209,15 +209,6 @@ public class BasicEnhancementTest {
         public Object writeObject(Object obj, String name, Object oldValue, Object newValue) {
             return WRITE_MARKER;
         }
-
-        @Override
-        public Set<String> getInitializedLazyAttributeNames() {
-            return null;
-        }
-
-        @Override
-        public void attributeInitialized(String name) {
-        }
     }
 
     // --- //

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/BidirectionalLazyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/BidirectionalLazyTest.java
@@ -79,10 +79,12 @@ public class BidirectionalLazyTest extends BaseCoreFunctionalTestCase {
 		doInHibernate(
 				this::sessionFactory, session -> {
 					Employer employer = session.get( Employer.class, "RedHat" );
+
 					// Delete the associated entity first
 					session.remove( employer );
+
 					for ( Employee employee : employer.getEmployees() ) {
-						assertFalse( Hibernate.isPropertyInitialized( employee, "employer" ) );
+						assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
 						session.remove( employee );
 						// Should be initialized because at least one entity was deleted beforehand
 						assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
@@ -188,23 +190,49 @@ public class BidirectionalLazyTest extends BaseCoreFunctionalTestCase {
 		doInHibernate(
 				this::sessionFactory, session -> {
 					Employee employee = session.get( Employee.class, "Jack" );
+					assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
 
 					// Get and delete an Employer that is not associated with employee
 					Employer employer = session.get( Employer.class, "RedHat" );
 					session.remove( employer );
 
-					// employee.employer is uninitialized. Since the column for employee.employer
-					// is a foreign key, and there is an Employer that has already been removed,
-					// employee.employer will need to be iniitialized to determine if
-					// employee.employee is nullifiable.
-					assertFalse( Hibernate.isPropertyInitialized( employee, "employer" ) );
+					assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
 					session.remove( employee );
 					assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
 				}
 		);
+	}
 
+	/**
+	 * @implSpec Same as {@link #testRemoveEntityWithNullLazyManyToOne} but
+	 * deleting the Employer linked to the loaded Employee
+	 */
+	@Test
+	public void testRemoveEntityWithLinkedLazyManyToOne() {
+		inTransaction(
+				session -> {
+					Employer employer = new Employer( "RedHat" );
+					session.persist( employer );
+					Employee employee = new Employee( "Jack" );
+					employee.setEmployer( employer );
+					session.persist( employee );
+				}
+		);
 
+		inTransaction(
+				session -> {
+					Employee employee = session.get( Employee.class, "Jack" );
+					assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
 
+					// Get and delete an Employer that is not associated with employee
+					Employer employer = session.get( Employer.class, "RedHat" );
+					session.remove( employer );
+
+					assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
+					session.remove( employee );
+					assertTrue( Hibernate.isPropertyInitialized( employee, "employer" ) );
+				}
+		);
 	}
 
 	private void checkEntityEntryState(
@@ -274,8 +302,6 @@ public class BidirectionalLazyTest extends BaseCoreFunctionalTestCase {
 
 	@Entity(name = "Employee")
 	public static class Employee {
-		private long id;
-
 		private String name;
 
 		private Employer employer;
@@ -283,10 +309,6 @@ public class BidirectionalLazyTest extends BaseCoreFunctionalTestCase {
 		public Employee(String name) {
 			this();
 			setName( name );
-		}
-
-		public long getId() {
-			return id;
 		}
 
 		@Id
@@ -303,10 +325,6 @@ public class BidirectionalLazyTest extends BaseCoreFunctionalTestCase {
 
 		protected Employee() {
 			// this form used by Hibernate
-		}
-
-		protected void setId(long id) {
-			this.id = id;
 		}
 
 		protected void setName(String name) {

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/AbstractKey.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/AbstractKey.java
@@ -1,0 +1,123 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.group;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.LazyGroup;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Table(name = "PP_DCKey")
+public abstract class AbstractKey extends ModelEntity
+		implements Serializable {
+
+	@Column(name = "Name")
+	String name;
+
+	@OneToMany(targetEntity = RoleEntity.class, mappedBy = "key", fetch = FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("R")
+	protected Set<RoleEntity> roles = new LinkedHashSet<>();
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("PR")
+	@JoinColumn
+	protected AbstractKey register;
+
+	@OneToMany(targetEntity = AbstractKey.class, mappedBy = "register", fetch = FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("RK")
+	protected Set<AbstractKey> keys = new LinkedHashSet();
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("PP")
+	@JoinColumn
+	protected AbstractKey parent;
+
+	@OneToMany(targetEntity = AbstractKey.class, mappedBy = "parent", fetch = FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("PK")
+	protected Set<AbstractKey> otherKeys = new LinkedHashSet();
+
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Set<RoleEntity> getRoles() {
+		return roles;
+	}
+
+	public void setRoles(Set<RoleEntity> role) {
+		this.roles = role;
+	}
+
+	public void addRole(RoleEntity role) {
+		this.roles.add( role );
+	}
+
+	public AbstractKey getRegister() {
+		return register;
+	}
+
+	public void setRegister(AbstractKey register) {
+		this.register = register;
+	}
+
+	public Set<AbstractKey> getKeys() {
+		return keys;
+	}
+
+	public void setKeys(Set<AbstractKey> keys) {
+		this.keys = keys;
+	}
+
+	public void addRegisterKey(AbstractKey registerKey) {
+		keys.add( registerKey );
+	}
+
+	public AbstractKey getParent() {
+		return parent;
+	}
+
+	public void setParent(AbstractKey parent) {
+		this.parent = parent;
+	}
+
+	public Set<AbstractKey> getOtherKeys() {
+		return otherKeys;
+	}
+
+	public void setOtherKeys(Set<AbstractKey> otherKeys) {
+		this.otherKeys = otherKeys;
+	}
+
+	public void addPanelKey(AbstractKey panelKey) {
+		this.otherKeys.add( panelKey );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/ComplexFetchGroupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/ComplexFetchGroupTest.java
@@ -25,6 +25,8 @@ import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.SessionStatistics;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
@@ -33,6 +35,7 @@ import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -189,6 +192,11 @@ public class ComplexFetchGroupTest extends BaseNonConfigCoreFunctionalTestCase {
 		);
 	}
 
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PPROXY, "true" );
+	}
 
 	@Override
 	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
@@ -261,6 +269,19 @@ public class ComplexFetchGroupTest extends BaseNonConfigCoreFunctionalTestCase {
 					session.save(c);
 					session.save(d);
 					session.save(e);
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from E" ).executeUpdate();
+					session.createQuery( "delete from D" ).executeUpdate();
+					session.createQuery( "delete from C" ).executeUpdate();
+					session.createQuery( "delete from B" ).executeUpdate();
+					session.createQuery( "delete from A" ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/ComplexFetchGroupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/ComplexFetchGroupTest.java
@@ -8,6 +8,7 @@ package org.hibernate.test.bytecode.enhancement.lazy.group;
 
 import java.sql.Blob;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import javax.persistence.Basic;
@@ -33,7 +34,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.proxy.HibernateProxy;
-import org.hibernate.stat.SessionStatistics;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
 import org.hibernate.testing.TestForIssue;
@@ -251,6 +251,35 @@ public class ComplexFetchGroupTest extends BaseNonConfigCoreFunctionalTestCase {
 		);
 	}
 
+	@Test
+	public void testAbstractClassAssociation() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		inTransaction(
+				session -> {
+					final String qry = "select e from RoleEntity e";
+					final List<RoleEntity> keyRolleEntitys = session.createQuery( qry, RoleEntity.class ).list();
+
+					assertThat( stats.getPrepareStatementCount(), is( 2L ) );
+
+					for ( RoleEntity keyRolleEntity : keyRolleEntitys ) {
+						Set<SpecializedEntity> specializedEntities = ( (SpecializedKey) keyRolleEntity.getKey() )
+								.getSpecializedEntities();
+						assertThat( stats.getPrepareStatementCount(), is( 3L ) );
+
+						Iterator<SpecializedEntity> iterator = specializedEntities.iterator();
+						while ( iterator.hasNext() ) {
+							iterator.next().getId();
+						}
+
+						// but regardless there should not be an additional query
+						assertThat( stats.getPrepareStatementCount(), is( 3L ) );
+					}
+				}
+		);
+	}
+
 	@Override
 	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
 		super.configureStandardServiceRegistryBuilder( ssrb );
@@ -276,6 +305,12 @@ public class ComplexFetchGroupTest extends BaseNonConfigCoreFunctionalTestCase {
 
 		sources.addAnnotatedClass( Activity.class );
 		sources.addAnnotatedClass( Instruction.class );
+
+		sources.addAnnotatedClass( SpecializedKey.class );
+		sources.addAnnotatedClass( RoleEntity.class );
+		sources.addAnnotatedClass( AbstractKey.class );
+		sources.addAnnotatedClass( GenericKey.class );
+		sources.addAnnotatedClass( SpecializedEntity.class );
 	}
 
 	@Before
@@ -349,6 +384,24 @@ public class ComplexFetchGroupTest extends BaseNonConfigCoreFunctionalTestCase {
 						final Activity activity = new Activity( i, "Activity #" + i, instr );
 						session.save( activity );
 					}
+
+					RoleEntity roleEntity = new RoleEntity();
+					roleEntity.setOid( 1L );
+
+					SpecializedKey specializedKey = new SpecializedKey();
+					specializedKey.setOid(1L);
+
+					SpecializedEntity specializedEntity = new SpecializedEntity();
+					specializedEntity.setId( 2L );
+					specializedKey.addSpecializedEntity( specializedEntity );
+					specializedEntity.setSpecializedKey( specializedKey);
+
+					specializedKey.addRole( roleEntity );
+					roleEntity.setKey( specializedKey );
+
+					session.save( specializedEntity );
+					session.save( roleEntity );
+					session.save( specializedKey );
 				}
 		);
 	}
@@ -365,6 +418,12 @@ public class ComplexFetchGroupTest extends BaseNonConfigCoreFunctionalTestCase {
 
 					session.createQuery( "delete from Activity" ).executeUpdate();
 					session.createQuery( "delete from Instruction" ).executeUpdate();
+
+					session.createQuery( "delete from SpecializedEntity" ).executeUpdate();
+					session.createQuery( "delete from RoleEntity" ).executeUpdate();
+					session.createQuery( "delete from SpecializedKey" ).executeUpdate();
+					session.createQuery( "delete from GenericKey" ).executeUpdate();
+					session.createQuery( "delete from AbstractKey" ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/GenericKey.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/GenericKey.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.group;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+@Entity(name="GenericKey")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Table(name="PP_GenericDCKey")
+public abstract class GenericKey extends AbstractKey implements Serializable {
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/ModelEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/ModelEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.group;
+
+import java.sql.Timestamp;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+@MappedSuperclass
+public abstract class ModelEntity {
+
+	@Id
+	@Column(name="Oid")
+	private Long Oid = null;
+
+	@Basic
+	@Column(name="CreatedAt")
+	private Timestamp CreatedAt = null;
+
+	@Basic
+	@Column(name="CreatedBy")
+	private String CreatedBy = null;
+
+	@Basic
+	@Column(name="VersionNr")
+	private short VersionNr = 0;
+
+	public short getVersionNr() {
+		return VersionNr;
+	}
+
+	public void setVersionNr(short versionNr) {
+		this.VersionNr = versionNr;
+	}
+
+	public Long getOid() {
+		return Oid;
+	}
+
+	public void setOid(Long oid) {
+		this.Oid = oid;
+	}
+
+	public Timestamp getCreatedAt() {
+		return CreatedAt;
+	}
+
+	public void setCreatedAt(Timestamp createdAt) {
+		this.CreatedAt = createdAt;
+	}
+
+	public String getCreatedBy() {
+		return CreatedBy;
+	}
+
+	public void setCreatedBy(String createdBy) {
+		this.CreatedBy = createdBy;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/MoreSpecializedKey.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/MoreSpecializedKey.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.group;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+@Entity(name="MoreSpecializedKey")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public class MoreSpecializedKey extends SpecializedKey implements Serializable {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/RoleEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/RoleEntity.java
@@ -31,13 +31,13 @@ public class RoleEntity extends ModelEntity implements Serializable {
 	Short value;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyToOne(LazyToOneOption.PROXY)
 	@LazyGroup("Key")
 	@JoinColumn
 	protected AbstractKey key = null;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyToOne(LazyToOneOption.PROXY)
 	@LazyGroup("Key")
 	@JoinColumn
 	protected SpecializedKey specializedKey = null;

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/RoleEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/RoleEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.group;
+
+
+import java.io.Serializable;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.LazyGroup;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+
+@Entity(name = "RoleEntity")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Table(name = "PP_DCRolleKey")
+public class RoleEntity extends ModelEntity implements Serializable {
+
+	@Basic
+	Short value;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("Key")
+	@JoinColumn
+	protected AbstractKey key = null;
+
+	public Short getValue() {
+		return value;
+	}
+
+	public void setvalue(Short value) {
+		this.value = value;
+	}
+
+	public AbstractKey getKey() {
+		return key;
+	}
+
+	public void setKey(AbstractKey key) {
+		this.key = key;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/RoleEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/RoleEntity.java
@@ -36,6 +36,12 @@ public class RoleEntity extends ModelEntity implements Serializable {
 	@JoinColumn
 	protected AbstractKey key = null;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("Key")
+	@JoinColumn
+	protected SpecializedKey specializedKey = null;
+
 	public Short getValue() {
 		return value;
 	}
@@ -50,5 +56,13 @@ public class RoleEntity extends ModelEntity implements Serializable {
 
 	public void setKey(AbstractKey key) {
 		this.key = key;
+	}
+
+	public SpecializedKey getSpecializedKey() {
+		return specializedKey;
+	}
+
+	public void setSpecializedKey(SpecializedKey specializedKey) {
+		this.specializedKey = specializedKey;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SimpleLazyGroupUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SimpleLazyGroupUpdateTest.java
@@ -64,7 +64,7 @@ public class SimpleLazyGroupUpdateTest extends BaseCoreFunctionalTestCase {
     @Test
     public void test() {
         doInHibernate( this::sessionFactory, s -> {
-            TestEntity entity = s.load( TestEntity.class, 1L );
+            TestEntity entity = s.get( TestEntity.class, 1L );
             assertLoaded( entity, "name" );
             assertNotLoaded( entity, "lifeStory" );
             assertNotLoaded( entity, "reallyBigString" );
@@ -76,7 +76,7 @@ public class SimpleLazyGroupUpdateTest extends BaseCoreFunctionalTestCase {
         } );
 
         doInHibernate( this::sessionFactory, s -> {
-            TestEntity entity = s.load( TestEntity.class, 1L );
+            TestEntity entity = s.get( TestEntity.class, 1L );
 
             assertLoaded( entity, "name" );
             assertNotLoaded( entity, "lifeStory" );

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedEntity.java
@@ -43,7 +43,7 @@ public class SpecializedEntity implements Serializable {
 	String value;
 
 	@ManyToOne(fetch=FetchType.LAZY)
-	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyToOne(LazyToOneOption.PROXY)
 	@LazyGroup("SpecializedKey")
 	@JoinColumn
 	protected SpecializedKey specializedKey = null;

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.group;
+
+import java.io.Serializable;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.LazyGroup;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+
+
+@Entity(name="SpecializedEntity")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Table(name="PP_PartnerZusatzKuerzelZR")
+public class SpecializedEntity implements Serializable {
+
+	@Id
+	Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@Column(name="Value")
+	String value;
+
+	@ManyToOne(fetch=FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("SpecializedKey")
+	@JoinColumn
+	protected SpecializedKey specializedKey = null;
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public SpecializedKey getSpecializedKey() {
+		return specializedKey;
+	}
+
+	public void setSpecializedKey(SpecializedKey specializedKey) {
+			this.specializedKey = specializedKey;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedKey.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedKey.java
@@ -1,13 +1,6 @@
 /*
  * Hibernate, Relational Persistence for Idiomatic Java
  *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
-
-/*
- * Hibernate, Relational Persistence for Idiomatic Java
- *
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
  */

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedKey.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedKey.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.group;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.LazyGroup;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+
+@Entity(name="SpecializedKey")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Table(name="PP_PartnerDCKey")
+public class SpecializedKey extends GenericKey implements Serializable
+{
+
+	@OneToMany(targetEntity= SpecializedEntity.class, mappedBy="specializedKey", fetch=FetchType.LAZY)
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@LazyGroup("PZ")
+	protected Set<SpecializedEntity> specializedEntities = new LinkedHashSet();
+
+	public Set<SpecializedEntity> getSpecializedEntities() {
+		return specializedEntities;
+	}
+
+	public void setSpecializedEntities(Set<SpecializedEntity> specializedEntities) {
+		this. specializedEntities = specializedEntities;
+	}
+
+	public void addSpecializedEntity(SpecializedEntity pPartnerZusatzkuerzelZR) {
+		this.specializedEntities.add( pPartnerZusatzkuerzelZR);
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedKey.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/group/SpecializedKey.java
@@ -27,7 +27,6 @@ public class SpecializedKey extends GenericKey implements Serializable
 {
 
 	@OneToMany(targetEntity= SpecializedEntity.class, mappedBy="specializedKey", fetch=FetchType.LAZY)
-	@LazyToOne(LazyToOneOption.NO_PROXY)
 	@LazyGroup("PZ")
 	protected Set<SpecializedEntity> specializedEntities = new LinkedHashSet();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LobUnfetchedPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LobUnfetchedPropertyTest.java
@@ -115,6 +115,7 @@ public class LobUnfetchedPropertyTest extends BaseCoreFunctionalTestCase {
 			FileNClob file = s.get( FileNClob.class, id );
 			assertFalse( Hibernate.isPropertyInitialized( file, "clob" ) );
 			NClob nClob = file.getClob();
+			assertTrue( Hibernate.isPropertyInitialized( file, "clob" ) );
 			try {
 			   final char[] chars = new char[(int) file.getClob().length()];
 			   nClob.getCharacterStream().read( chars );


### PR DESCRIPTION
the ```EntityType```  adds the value of ```unwrapProxy``` to the new ```SharesSessionContractImplementor#internalLoad``` so that it can be added to the ```LoadEventListener.LoadType type;``` (line 1168) and then be accessed and used by the ```DefaultLoadEventListener``` (line 297)


