### PR TITLE
Wip/sqm jpa types sql ast

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelExpressable.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelExpressable.java
@@ -30,7 +30,9 @@ public interface MappingModelExpressable<T> {
 	//
 	// todo (6.0) : IMO `Bindable` should be consumed here and `Bindable` go away
 
-	void visitJdbcTypes(Consumer<SqlExpressableType> action, TypeConfiguration typeConfiguration);
+	default void visitJdbcTypes(Consumer<SqlExpressableType> action, TypeConfiguration typeConfiguration){
+		throw new NotYetImplementedFor6Exception( getClass() );
+	}
 
 	default Bindable getBindable() {
 		throw new NotYetImplementedFor6Exception( getClass() );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractIdentifiableType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractIdentifiableType.java
@@ -269,18 +269,18 @@ public abstract class AbstractIdentifiableType<J>
 		}
 	}
 
-	@Override
-	public void visitJdbcTypes(Consumer action, TypeConfiguration typeConfiguration) {
-		id.visitJdbcTypes( action, typeConfiguration );
-
-		if ( versionAttribute != null ) {
-			versionAttribute.visitJdbcTypes( action, typeConfiguration );
-		}
-
-		visitAttributes(
-				attribute -> attribute.visitJdbcTypes( action, typeConfiguration )
-		);
-	}
+//	@Override
+//	public void visitJdbcTypes(Consumer action, TypeConfiguration typeConfiguration) {
+//		id.visitJdbcTypes( action, typeConfiguration );
+//
+//		if ( versionAttribute != null ) {
+//			versionAttribute.visitJdbcTypes( action, typeConfiguration );
+//		}
+//
+//		visitAttributes(
+//				attribute -> attribute.visitJdbcTypes( action, typeConfiguration )
+//		);
+//	}
 
 	/**
 	 * For used to retrieve the declared version when populating the static metamodel.

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
@@ -53,6 +53,7 @@ public abstract class AbstractPluralAttribute<D,C,E>
 
 		this.elementPathSource = DomainModelHelper.resolveSqmPathSource(
 				getName(),
+				getMappingRole(),
 				builder.getValueType(),
 				BindableType.PLURAL_ATTRIBUTE
 		);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingSqmPathSource.java
@@ -19,9 +19,10 @@ public class AnyMappingSqmPathSource<J> extends AbstractSqmPathSource<J> {
 	@SuppressWarnings("WeakerAccess")
 	public AnyMappingSqmPathSource(
 			String localPathName,
+			String roleName,
 			AnyMappingDomainType<J> domainType,
 			BindableType jpaBindableType) {
-		super( localPathName, domainType, jpaBindableType );
+		super( localPathName, roleName, domainType, jpaBindableType );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BagAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BagAttributeImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.metamodel.model.domain.internal;
 import java.util.Collection;
 
 import org.hibernate.NotYetImplementedFor6Exception;
+import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.model.domain.BagPersistentAttribute;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.hql.spi.SqmCreationState;
@@ -24,8 +25,8 @@ class BagAttributeImpl<X, E>
 		extends AbstractPluralAttribute<X, Collection<E>, E>
 		implements BagPersistentAttribute<X, E> {
 
-	BagAttributeImpl(PluralAttributeBuilder<X, Collection<E>, E, ?> xceBuilder) {
-		super( xceBuilder );
+	BagAttributeImpl(PluralAttributeBuilder<X, Collection<E>, E, ?> xceBuilder, MetadataContext metadataContext) {
+		super( xceBuilder, metadataContext );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DomainModelHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DomainModelHelper.java
@@ -80,12 +80,14 @@ public class DomainModelHelper {
 
 	public static <J> SqmPathSource<J> resolveSqmPathSource(
 			String name,
+			String roleName,
 			DomainType<J> valueDomainType,
 			Bindable.BindableType jpaBindableType) {
 
 		if ( valueDomainType instanceof BasicDomainType ) {
 			return new BasicSqmPathSource<>(
 					name,
+					roleName,
 					(BasicDomainType<J>) valueDomainType,
 					jpaBindableType
 			);
@@ -94,6 +96,7 @@ public class DomainModelHelper {
 		if ( valueDomainType instanceof AnyMappingDomainType ) {
 			return new AnyMappingSqmPathSource<>(
 					name,
+					roleName,
 					(AnyMappingDomainType<J>) valueDomainType,
 					jpaBindableType
 			);
@@ -102,6 +105,7 @@ public class DomainModelHelper {
 		if ( valueDomainType instanceof EmbeddableDomainType ) {
 			return new EmbeddedSqmPathSource<>(
 					name,
+					roleName,
 					(EmbeddableDomainType<J>) valueDomainType,
 					jpaBindableType
 			);
@@ -110,6 +114,7 @@ public class DomainModelHelper {
 		if ( valueDomainType instanceof EntityDomainType ) {
 			return new EntitySqmPathSource<>(
 					name,
+					roleName,
 					(EntityDomainType<J>) valueDomainType,
 					jpaBindableType
 			);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import java.util.List;
 
+import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.model.domain.ListPersistentAttribute;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.hql.spi.SqmCreationState;
@@ -22,12 +23,13 @@ import org.hibernate.query.sqm.tree.from.SqmFrom;
 class ListAttributeImpl<X, E> extends AbstractPluralAttribute<X, List<E>, E> implements ListPersistentAttribute<X, E> {
 	private final SqmPathSource<Integer> indexPathSource;
 
-	ListAttributeImpl(PluralAttributeBuilder<X, List<E>, E, ?> builder) {
-		super( builder );
+	ListAttributeImpl(PluralAttributeBuilder<X, List<E>, E, ?> builder, MetadataContext metadataContext) {
+		super( builder, metadataContext );
 
 		//noinspection unchecked
 		this.indexPathSource = (SqmPathSource) DomainModelHelper.resolveSqmPathSource(
 				getName(),
+				getMappingRole(),
 				builder.getListIndexOrMapKeyType(),
 				BindableType.PLURAL_ATTRIBUTE
 		);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.metamodel.model.domain.internal;
 import java.util.Map;
 
 import org.hibernate.NotYetImplementedFor6Exception;
+import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.model.domain.MapPersistentAttribute;
 import org.hibernate.metamodel.model.domain.SimpleDomainType;
 import org.hibernate.query.sqm.SqmPathSource;
@@ -24,11 +25,12 @@ import org.hibernate.query.sqm.tree.from.SqmFrom;
 class MapAttributeImpl<X, K, V> extends AbstractPluralAttribute<X, Map<K, V>, V> implements MapPersistentAttribute<X, K, V> {
 	private final SqmPathSource<K> keyPathSource;
 
-	MapAttributeImpl(PluralAttributeBuilder<X, Map<K, V>, V, K> xceBuilder) {
-		super( xceBuilder );
+	MapAttributeImpl(PluralAttributeBuilder<X, Map<K, V>, V, K> xceBuilder, MetadataContext metadataContext) {
+		super( xceBuilder, metadataContext );
 
 		this.keyPathSource = DomainModelHelper.resolveSqmPathSource(
 				getName(),
+				getMappingRole(),
 				xceBuilder.getListIndexOrMapKeyType(),
 				BindableType.PLURAL_ATTRIBUTE
 		);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
@@ -86,42 +86,42 @@ public class PluralAttributeBuilder<D, C, E, K> {
 
 		if ( Map.class.equals( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new MapAttributeImpl<>( builder );
+			return new MapAttributeImpl<>( builder, metadataContext );
 		}
 		else if ( Set.class.equals( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new SetAttributeImpl<>( builder );
+			return new SetAttributeImpl<>( builder, metadataContext );
 		}
 		else if ( List.class.equals( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new ListAttributeImpl<>( builder );
+			return new ListAttributeImpl<>( builder, metadataContext );
 		}
 		else if ( Collection.class.equals( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new BagAttributeImpl<>( builder );
+			return new BagAttributeImpl<>( builder, metadataContext );
 		}
 
 		//apply loose rules
 		if ( attributeJtd.getJavaType().isArray() ) {
 			//noinspection unchecked
-			return new ListAttributeImpl<>( builder );
+			return new ListAttributeImpl<>( builder, metadataContext );
 		}
 
 		if ( Map.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new MapAttributeImpl<>( builder );
+			return new MapAttributeImpl<>( builder, metadataContext );
 		}
 		else if ( Set.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new SetAttributeImpl<>( builder );
+			return new SetAttributeImpl<>( builder, metadataContext );
 		}
 		else if ( List.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new ListAttributeImpl<>( builder );
+			return new ListAttributeImpl<>( builder, metadataContext );
 		}
 		else if ( Collection.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
 			//noinspection unchecked
-			return new BagAttributeImpl<>( builder );
+			return new BagAttributeImpl<>( builder, metadataContext );
 		}
 
 		throw new UnsupportedOperationException( "Unknown collection: " + attributeJtd.getJavaType() );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SetAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SetAttributeImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import java.util.Set;
 
+import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.model.domain.SetPersistentAttribute;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.tree.SqmJoinType;
@@ -20,8 +21,8 @@ import org.hibernate.query.sqm.tree.from.SqmFrom;
  */
 public class SetAttributeImpl<X, E> extends AbstractPluralAttribute<X, Set<E>, E>
 		implements SetPersistentAttribute<X, E> {
-	public SetAttributeImpl(PluralAttributeBuilder<X, Set<E>, E, ?> xceBuilder) {
-		super( xceBuilder );
+	public SetAttributeImpl(PluralAttributeBuilder<X, Set<E>, E, ?> xceBuilder, MetadataContext metadataContext) {
+		super( xceBuilder, metadataContext );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
@@ -67,6 +67,7 @@ public class SingularAttributeImpl<D,J>
 
 		this.sqmPathSource = DomainModelHelper.resolveSqmPathSource(
 				name,
+				getMappingRole(),
 				attributeType,
 				BindableType.SINGULAR_ATTRIBUTE
 		);

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -163,6 +163,7 @@ import org.hibernate.type.EntityType;
 import org.hibernate.type.Type;
 import org.hibernate.type.TypeHelper;
 import org.hibernate.type.VersionType;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * Basic functionality for persisting an entity via JDBC
@@ -1865,6 +1866,11 @@ public abstract class AbstractEntityPersister
 				.setOuterJoins( "", "" )
 				.setWhereClause( whereClause )
 				.toStatementString();
+	}
+
+	@Override
+	public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+		return getEntityKeyDefinition().getExpressableJavaTypeDescriptor();
 	}
 
 	protected interface InclusionChecker {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -9,6 +9,7 @@ package org.hibernate.persister.entity;
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.QueryException;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.cache.spi.access.EntityDataAccess;
@@ -41,6 +42,8 @@ import org.hibernate.sql.SelectFragment;
 import org.hibernate.type.DiscriminatorType;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+
 import org.jboss.logging.Logger;
 
 import java.io.Serializable;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -17,7 +17,6 @@ import java.util.Set;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
-import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
@@ -44,7 +43,6 @@ import org.hibernate.sql.SelectFragment;
 import org.hibernate.type.AssociationType;
 import org.hibernate.type.DiscriminatorType;
 import org.hibernate.type.Type;
-import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * The default implementation of the <tt>EntityPersister</tt> interface.

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
@@ -43,6 +44,7 @@ import org.hibernate.sql.SelectFragment;
 import org.hibernate.type.AssociationType;
 import org.hibernate.type.DiscriminatorType;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * The default implementation of the <tt>EntityPersister</tt> interface.

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -19,6 +19,7 @@ import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.MappingException;
+import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
@@ -43,6 +44,7 @@ import org.hibernate.sql.SelectFragment;
 import org.hibernate.sql.SimpleSelect;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * Implementation of the "table-per-concrete-class" or "roll-down" mapping

--- a/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/CompositionSingularSubAttributesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/CompositionSingularSubAttributesHelper.java
@@ -142,6 +142,11 @@ public final class CompositionSingularSubAttributesHelper {
 							return new AssociationAttributeDefinition() {
 
 								@Override
+								public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+									return source.getExpressableJavaTypeDescriptor();
+								}
+
+								@Override
 								public void visitJdbcTypes(
 										Consumer action,
 										TypeConfiguration typeConfiguration) {
@@ -242,6 +247,11 @@ public final class CompositionSingularSubAttributesHelper {
 						else if ( type.isComponentType() ) {
 							return new CompositionDefinition() {
 								@Override
+								public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+									return source.getExpressableJavaTypeDescriptor();
+								}
+
+								@Override
 								public String getName() {
 									return name;
 								}
@@ -275,6 +285,11 @@ public final class CompositionSingularSubAttributesHelper {
 						}
 						else {
 							return new AttributeDefinition() {
+								@Override
+								public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+									return source.getExpressableJavaTypeDescriptor();
+								}
+
 								@Override
 								public String getName() {
 									return name;

--- a/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/CompositionSingularSubAttributesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/CompositionSingularSubAttributesHelper.java
@@ -140,10 +140,6 @@ public final class CompositionSingularSubAttributesHelper {
 						if ( type.isAssociationType() ) {
 							final AssociationType aType = (AssociationType) type;
 							return new AssociationAttributeDefinition() {
-								@Override
-								public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
-									return ;
-								}
 
 								@Override
 								public void visitJdbcTypes(

--- a/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/EntityIdentifierDefinitionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/EntityIdentifierDefinitionHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.persister.walking.internal;
 
+import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.persister.entity.AbstractEntityPersister;
 import org.hibernate.persister.walking.spi.AttributeDefinition;
 import org.hibernate.persister.walking.spi.AttributeSource;
@@ -16,6 +17,7 @@ import org.hibernate.persister.walking.spi.EntityIdentifierDefinition;
 import org.hibernate.persister.walking.spi.NonEncapsulatedEntityIdentifierDefinition;
 import org.hibernate.type.CompositeType;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * @author Gail Badner

--- a/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/EntityIdentifierDefinitionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/walking/internal/EntityIdentifierDefinitionHelper.java
@@ -28,6 +28,11 @@ public final class EntityIdentifierDefinitionHelper {
 
 	public static EntityIdentifierDefinition buildSimpleEncapsulatedIdentifierDefinition(final AbstractEntityPersister entityPersister) {
 		return new EncapsulatedEntityIdentifierDefinition() {
+			@Override
+			public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+				return entityPersister.getEntityKeyDefinition().getExpressableJavaTypeDescriptor();
+			}
+
 			private final AttributeDefinitionAdapter attr = new AttributeDefinitionAdapter( entityPersister);
 
 			@Override
@@ -51,6 +56,11 @@ public final class EntityIdentifierDefinitionHelper {
 			final AbstractEntityPersister entityPersister) {
 
 		return new EncapsulatedEntityIdentifierDefinition() {
+			@Override
+			public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+				return entityPersister.getExpressableJavaTypeDescriptor();
+			}
+
 			private final CompositionDefinitionAdapter compositionDefinition = new CompositionDefinitionAdapter( entityPersister );
 
 			@Override
@@ -72,6 +82,11 @@ public final class EntityIdentifierDefinitionHelper {
 
 	public static EntityIdentifierDefinition buildNonEncapsulatedCompositeIdentifierDefinition(final AbstractEntityPersister entityPersister) {
 		return new NonEncapsulatedEntityIdentifierDefinition() {
+			@Override
+			public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+				return entityPersister.getEntityKeyDefinition().getExpressableJavaTypeDescriptor();
+			}
+
 			private final CompositionDefinitionAdapter compositionDefinition = new CompositionDefinitionAdapter( entityPersister );
 
 			@Override
@@ -159,6 +174,11 @@ public final class EntityIdentifierDefinitionHelper {
 		protected AbstractEntityPersister getEntityPersister() {
 			return entityPersister;
 		}
+
+		@Override
+		public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+			return getEntityPersister().getEntityKeyDefinition().getExpressableJavaTypeDescriptor();
+		}
 	}
 
 	private static class CompositionDefinitionAdapter extends AttributeDefinitionAdapter implements CompositionDefinition {
@@ -179,6 +199,11 @@ public final class EntityIdentifierDefinitionHelper {
 		@Override
 		public Iterable<AttributeDefinition> getAttributes() {
 			return  CompositionSingularSubAttributesHelper.getIdentifierSubAttributes( getEntityPersister() );
+		}
+
+		@Override
+		public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+			return getEntityPersister().getEntityKeyDefinition().getExpressableJavaTypeDescriptor();
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/FullyQualifiedReflectivePathTerminal.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/FullyQualifiedReflectivePathTerminal.java
@@ -239,4 +239,8 @@ public class FullyQualifiedReflectivePathTerminal
 		return null;
 	}
 
+	@Override
+	public SqmExpressable getExpressableType() {
+		return expressableType;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -673,7 +673,7 @@ public abstract class BaseSqmToSqlAstConverter
 
 
 	private final Stack<Supplier<MappingModelExpressable>> inferableTypeAccessStack = new StandardStack<>(
-			() -> () -> null
+			() -> null
 	);
 
 	private void resolveSqmParameter(SqmParameter expression, MappingModelExpressable valueMapping, Consumer<JdbcParameter> jdbcParameterConsumer) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmPathInterpretation.java
@@ -31,9 +31,9 @@ public interface SqmPathInterpretation<T> extends SqmExpressionInterpretation<T>
 
 	SqmPathSource<T> getSqmPathSource();
 
-	@Override
-	default Expression toSqlExpression(SqlAstCreationState sqlAstCreationState) {
-		throw new NotYetImplementedFor6Exception( getClass() );
+//	@Override
+//	default Expression toSqlExpression(SqlAstCreationState sqlAstCreationState) {
+//		throw new NotYetImplementedFor6Exception( getClass() );
 //		final TableGroup tableGroup;
 //
 //		if ( getSqmPathSource() instanceof BasicSqmPathSource ) {
@@ -65,5 +65,5 @@ public interface SqmPathInterpretation<T> extends SqmExpressionInterpretation<T>
 //		}
 //
 //		return new SqlTuple( list, sqlAstCreationState.getExpressableType() );
-	}
+//	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
@@ -107,6 +107,11 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
+	public String getMappingRole() {
+		return getHibernateEntityName();
+	}
+
+	@Override
 	public String getPathName() {
 		return getName();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/AbstractNonIdentifierAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/AbstractNonIdentifierAttribute.java
@@ -11,6 +11,7 @@ import org.hibernate.engine.spi.CascadeStyle;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.persister.walking.spi.AttributeSource;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * @author Steve Ebersole
@@ -111,5 +112,10 @@ public abstract class AbstractNonIdentifierAttribute extends AbstractAttribute i
 	@Override
 	public String toString() {
 		return "Attribute(name=" + getName() + ", type=" + getType().getName() + " [" + loggableMetadata() + "])";
+	}
+
+	@Override
+	public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+		return source().getExpressableJavaTypeDescriptor();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityBasedAssociationAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityBasedAssociationAttribute.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.tuple.entity;
 
+import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.engine.FetchStrategy;
 import org.hibernate.engine.FetchStyle;
 import org.hibernate.engine.internal.JoinHelper;
@@ -30,6 +31,7 @@ import org.hibernate.tuple.BaselineAttributeInformation;
 import org.hibernate.type.AnyType;
 import org.hibernate.type.AssociationType;
 import org.hibernate.type.ForeignKeyDirection;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 import static org.hibernate.engine.internal.JoinHelper.getLHSColumnNames;
 import static org.hibernate.engine.internal.JoinHelper.getLHSTableName;

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/VersionProperty.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/VersionProperty.java
@@ -12,6 +12,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.tuple.AbstractNonIdentifierAttribute;
 import org.hibernate.tuple.BaselineAttributeInformation;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * Represents a version property within the Hibernate runtime-metamodel.

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ejb3configuration/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ejb3configuration/PersisterClassProviderTest.java
@@ -55,6 +55,7 @@ import org.hibernate.tuple.entity.EntityMetamodel;
 import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.type.Type;
 import org.hibernate.type.VersionType;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -657,6 +658,11 @@ public class PersisterClassProviderTest {
 		@Override
 		public boolean isAffectedByEnabledFetchProfiles(LoadQueryInfluencers influencers) {
 			return false;
+		}
+
+		@Override
+		public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+			return null;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -56,6 +56,7 @@ import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.Type;
 import org.hibernate.type.VersionType;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * @author Emmanuel Bernard <emmanuel@hibernate.org>
@@ -643,6 +644,11 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		@Override
 		public boolean isAffectedByEnabledFetchProfiles(LoadQueryInfluencers influencers) {
 			return false;
+		}
+
+		@Override
+		public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+			return null;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
@@ -56,6 +56,7 @@ import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
 import org.hibernate.type.VersionType;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 public class CustomPersister implements EntityPersister {
 
@@ -754,5 +755,10 @@ public class CustomPersister implements EntityPersister {
 	@Override
 	public boolean isAffectedByEnabledFilters(LoadQueryInfluencers loadQueryInfluencers) {
 		return false;
+	}
+
+	@Override
+	public JavaTypeDescriptor getExpressableJavaTypeDescriptor() {
+		return getEntityKeyDefinition().getExpressableJavaTypeDescriptor();
 	}
 }


### PR DESCRIPTION
Hi @sebersole, 
this PR fixes all the compilation errors but not sure about 

- `MappingModelExpressable#getExpressableJavaTypeDescriptor90` implementations,

- if the `AbstractAttribute`  `mappingRole`  is the correct value for the `roleName` parameter of `DomainModelHelper.resolveSqmPathSource(String name,

			String roleName,
			DomainType<J> valueDomainType,
			Bindable.BindableType jpaBindableType)`
 (see https://github.com/sebersole/hibernate-core/compare/wip/sqm-jpa-types-sql-ast...dreab8:wip/sqm-jpa-types-sql-ast?expand=1#diff-03d1dc4b28095b287a7fcb131a26ea0cR56

https://github.com/sebersole/hibernate-core/compare/wip/sqm-jpa-types-sql-ast...dreab8:wip/sqm-jpa-types-sql-ast?expand=1#diff-7a38409a8208b6e9132865a31541d680R32

https://github.com/sebersole/hibernate-core/compare/wip/sqm-jpa-types-sql-ast...dreab8:wip/sqm-jpa-types-sql-ast?expand=1#diff-8b63aa6633db32e7ee72d248b1a0f6e0R33

https://github.com/sebersole/hibernate-core/compare/wip/sqm-jpa-types-sql-ast...dreab8:wip/sqm-jpa-types-sql-ast?expand=1#diff-f50c31b1f7afe1f46615c5263952b362R70
)