### PR TITLE
Initial working support for building and executing JdbcSelect operati…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/internal/NamedEnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/internal/NamedEnumValueConverter.java
@@ -9,9 +9,12 @@ package org.hibernate.metamodel.model.convert.internal;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Locale;
 
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.model.convert.spi.EnumValueConverter;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
@@ -81,5 +84,15 @@ public class NamedEnumValueConverter<E extends Enum> implements EnumValueConvert
 
 		this.valueExtractor = sqlTypeDescriptor.getExtractor( relationalTypeDescriptor );
 		this.valueBinder = sqlTypeDescriptor.getBinder( relationalTypeDescriptor );
+	}
+
+	@Override
+	public void writeValue(
+			PreparedStatement statement,
+			Enum value,
+			int position,
+			SharedSessionContractImplementor session) throws SQLException {
+		final String jdbcValue = value == null ? null : value.name();
+		valueBinder.bind( statement, jdbcValue, position, session );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/internal/OrdinalEnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/internal/OrdinalEnumValueConverter.java
@@ -9,8 +9,11 @@ package org.hibernate.metamodel.model.convert.internal;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.model.convert.spi.EnumValueConverter;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
@@ -81,5 +84,13 @@ public class OrdinalEnumValueConverter<E extends Enum> implements EnumValueConve
 
 		this.valueExtractor = sqlTypeDescriptor.getExtractor( relationalJavaDescriptor );
 		this.valueBinder = sqlTypeDescriptor.getBinder( relationalJavaDescriptor );
+	}
+
+	@Override
+	public void writeValue(
+			PreparedStatement statement, Enum value, int position, SharedSessionContractImplementor session)
+			throws SQLException {
+		final Integer jdbcValue = value == null ? null : value.ordinal();
+		valueBinder.bind( statement, jdbcValue, position, session );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/spi/EnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/spi/EnumValueConverter.java
@@ -9,6 +9,7 @@ package org.hibernate.metamodel.model.convert.spi;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import org.hibernate.annotations.Remove;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.EnumJavaTypeDescriptor;
 
@@ -25,6 +26,7 @@ public interface EnumValueConverter<O extends Enum, R> extends BasicValueConvert
 
 	String toSqlLiteral(Object value);
 
+	@Remove
 	void writeValue(
 			PreparedStatement statement,
 			Enum value,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/spi/EnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/spi/EnumValueConverter.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.metamodel.model.convert.spi;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.EnumJavaTypeDescriptor;
 
 /**
@@ -20,4 +24,10 @@ public interface EnumValueConverter<O extends Enum, R> extends BasicValueConvert
 	int getJdbcTypeCode();
 
 	String toSqlLiteral(Object value);
+
+	void writeValue(
+			PreparedStatement statement,
+			Enum value,
+			int position,
+			SharedSessionContractImplementor session) throws SQLException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/StandardTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/StandardTableGroup.java
@@ -12,6 +12,9 @@ import java.util.function.Consumer;
 import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.NavigablePath;
+import org.hibernate.query.sqm.sql.SqlAstCreationState;
+import org.hibernate.query.sqm.sql.SqmToSqlAstConverter;
+import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.SqlAstWalker;
 
@@ -73,5 +76,11 @@ public class StandardTableGroup extends AbstractTableGroup {
 	@Override
 	public List<TableReferenceJoin> getTableReferenceJoins() {
 		return tableJoins;
+	}
+
+	@Override
+	public DomainResultProducer getDomainResultProducer(
+			SqmToSqlAstConverter walker, SqlAstCreationState sqlAstCreationState) {
+		return this;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
@@ -14,6 +14,7 @@ import org.hibernate.LockMode;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
+import org.hibernate.query.sqm.sql.internal.SqmSelectableInterpretation;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.SqlAstWalker;
 import org.hibernate.sql.ast.tree.SqlAstNode;
@@ -27,7 +28,8 @@ import org.hibernate.sql.results.spi.DomainResultCreationState;
  *
  * @author Steve Ebersole
  */
-public interface TableGroup extends SqlAstNode, ColumnReferenceQualifier, DomainResultProducer {
+public interface TableGroup
+		extends SqlAstNode, ColumnReferenceQualifier, DomainResultProducer,	SqmSelectableInterpretation {
 	NavigablePath getNavigablePath();
 
 	ModelPart getModelPart();

--- a/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
@@ -329,9 +329,8 @@ public class EnumType<T extends Enum>
 
 	@Override
 	public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session) throws HibernateException, SQLException {
-		throw new NotYetImplementedFor6Exception( getClass() );
-//		verifyConfigured();
-//		enumValueConverter.writeValue( st, (Enum) value, index, session );
+		verifyConfigured();
+		enumValueConverter.writeValue( st, (Enum) value, index, session );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.orm.test.sql.ast;
 
+import java.util.List;
+
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.orm.test.metamodel.mapping.SmokeTests.SimpleEntity;
 import org.hibernate.query.hql.spi.HqlQueryImplementor;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.sqm.internal.QuerySqmImpl;
@@ -30,13 +33,15 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hibernate.orm.test.metamodel.mapping.SmokeTests.Gender.FEMALE;
+import static org.hibernate.orm.test.metamodel.mapping.SmokeTests.Gender.MALE;
 
 /**
  * @author Steve Ebersole
  */
 @SuppressWarnings("WeakerAccess")
 @DomainModel(
-		annotatedClasses = org.hibernate.orm.test.metamodel.mapping.SmokeTests.SimpleEntity.class
+		annotatedClasses = SimpleEntity.class
 )
 @ServiceRegistry(
 		settings = @ServiceRegistry.Setting(
@@ -50,7 +55,10 @@ public class SmokeTests {
 	public void testSimpleHql(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					final QueryImplementor<String> query = session.createQuery( "select e.name from SimpleEntity e", String.class );
+					final QueryImplementor<String> query = session.createQuery(
+							"select e.name from SimpleEntity e",
+							String.class
+					);
 					final HqlQueryImplementor<String> hqlQuery = (HqlQueryImplementor<String>) query;
 					//noinspection unchecked
 					final SqmSelectStatement<String> sqmStatement = (SqmSelectStatement<String>) hqlQuery.getSqmStatement();
@@ -73,16 +81,10 @@ public class SmokeTests {
 							session.getSessionFactory()
 					);
 
-					assertThat( jdbcSelectOperation.getSql(), is( "select s1_0.name from mapping_simple_entity as s1_0" ) );
-				}
-		);
-	}
-	@Test
-	public void testSimpleHqlExecution(SessionFactoryScope scope) {
-		scope.inTransaction(
-				session -> {
-					final QueryImplementor<String> query = session.createQuery( "select e.name from SimpleEntity e", String.class );
-					query.list();
+					assertThat(
+							jdbcSelectOperation.getSql(),
+							is( "select s1_0.name from mapping_simple_entity as s1_0" )
+					);
 				}
 		);
 	}
@@ -105,7 +107,7 @@ public class SmokeTests {
 		assertThat( rootTableGroup.getPrimaryTableReference().getIdentificationVariable(), is( "s1_0" ) );
 
 		final SelectClause selectClause = sqlAst.getQuerySpec().getSelectClause();
-		assertThat( selectClause.getSqlSelections().size(), is( 1 ) ) ;
+		assertThat( selectClause.getSqlSelections().size(), is( 1 ) );
 		final SqlSelection sqlSelection = selectClause.getSqlSelections().get( 0 );
 		assertThat( sqlSelection.getJdbcResultSetIndex(), is( 1 ) );
 		assertThat( sqlSelection.getValuesArrayPosition(), is( 0 ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/exec/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/exec/SmokeTests.java
@@ -1,0 +1,101 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.sql.exec;
+
+import java.sql.Statement;
+import java.util.List;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.orm.test.metamodel.mapping.SmokeTests.SimpleEntity;
+import org.hibernate.query.spi.QueryImplementor;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hibernate.orm.test.metamodel.mapping.SmokeTests.Gender.FEMALE;
+import static org.hibernate.orm.test.metamodel.mapping.SmokeTests.Gender.MALE;
+
+/**
+ * @author Andrea Boriero
+ * @author Steve Ebersole
+ */
+@DomainModel(
+		annotatedClasses = SimpleEntity.class
+)
+@ServiceRegistry(
+		settings = @ServiceRegistry.Setting(
+				name = AvailableSettings.HBM2DDL_AUTO,
+				value = "create-drop"
+		)
+)
+@SessionFactory
+public class SmokeTests {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					SimpleEntity simpleEntity = new SimpleEntity();
+					simpleEntity.setId( 1 );
+					simpleEntity.setGender( FEMALE );
+					simpleEntity.setName( "Fab" );
+					simpleEntity.setGender2( MALE );
+					session.save( simpleEntity );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session ->
+						session.doWork(
+								work -> {
+									Statement statement = work.createStatement();
+									statement.execute( "delete from mapping_simple_entity" );
+									statement.close();
+								}
+						)
+		);
+	}
+
+	@Test
+	public void testSelectEntityFieldHqlExecution(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final QueryImplementor<String> query = session.createQuery(
+							"select e.name from SimpleEntity e",
+							String.class
+					);
+					List<String> simpleEntities = query.list();
+					assertThat( simpleEntities.size(), is( 1 ) );
+					assertThat( simpleEntities.get( 0 ), is( "Fab" ) );
+				}
+		);
+	}
+
+	@Test
+	public void testSelectEntityHqlExecution(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final QueryImplementor<SimpleEntity> query = session.createQuery(
+							"select e from SimpleEntity e",
+							SimpleEntity.class
+					);
+					List<SimpleEntity> simpleEntities = query.list();
+					assertThat( simpleEntities.size(), is( 1 ) );
+				}
+		);
+	}
+}


### PR DESCRIPTION
@sebersole basically the PR moves the `testSimpleHqlExecution` to `org.hibernate.orm.test.sql.exec.SmokeTests` and renamed it `testSelectEntityFieldHqlExecution`
The test also persists a SimpleEntity, but in order to do that I added  `EnumValueConverter#writevalue` but not sure this is the correct way.

Finally I added a new test `testSelectEntityHqlExecution` that is still failing.
