### PR TITLE
Wip/6.0 inheritance table per class

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5450,8 +5450,6 @@ public abstract class AbstractEntityPersister
 			return accessOptimizer.getPropertyValues( entity );
 		}
 
-		final Collection<AttributeMapping> attributeMappings = getAttributeMappings();
-
 		final Object[] result = new Object[this.attributeMappings.size()];
 		for ( int i = 0; i < this.attributeMappings.size(); i++ ) {
 			result[i] = this.attributeMappings.get( i ).getPropertyAccess().getGetter().getForInsert(
@@ -6070,7 +6068,7 @@ public abstract class AbstractEntityPersister
 	private List<AttributeMapping> attributeMappings;
 	private List<Fetchable> staticFetchableList;
 
-	private ReflectionOptimizer.AccessOptimizer accessOptimizer;
+	protected ReflectionOptimizer.AccessOptimizer accessOptimizer;
 
 	@Override
 	public void visitAttributeMappings(Consumer<AttributeMapping> action) {
@@ -6110,17 +6108,7 @@ public abstract class AbstractEntityPersister
 				);
 			}
 
-			if ( getDiscriminatorType() == null && shouldProcessSuperMapping() ) {
-				discriminatorMapping = null;
-			}
-			else {
-				discriminatorMapping = new EntityDiscriminatorMappingImpl(
-						this,
-						getRootTableName(),
-						getDiscriminatorColumnName(),
-						(BasicType) getDiscriminatorType()
-				);
-			}
+			buildDiscriminatorMapping();
 
 			// todo (6.0) : support for natural-id not yet implemented
 			naturalIdMapping = null;
@@ -6133,14 +6121,13 @@ public abstract class AbstractEntityPersister
 				.getEntityBinding( getEntityName() );
 
 		final EntityMetamodel currentEntityMetamodel = this.getEntityMetamodel();
-
-		int stateArrayPosition = superMappingType == null ? 0 : superMappingType.getNumberOfAttributeMappings();
+		int stateArrayPosition = getStateArrayInitialPosition( creationProcess );
 
 		for ( int i = 0; i < currentEntityMetamodel.getPropertySpan(); i++ ) {
 			final NonIdentifierAttribute runtimeAttrDefinition = currentEntityMetamodel.getProperties()[i];
 			final Property bootProperty = bootEntityDescriptor.getProperty( runtimeAttrDefinition.getName() );
 
-			if ( superMappingType != null && superMappingType.findAttributeMapping( bootProperty.getName() ) != null && shouldProcessSuperMapping() ) {
+			if ( superMappingType != null && superMappingType.findAttributeMapping( bootProperty.getName() ) != null ) {
 				// its defined on the super-type, skip it here
 			}
 			else {
@@ -6166,6 +6153,33 @@ public abstract class AbstractEntityPersister
 		}
 		else {
 			accessOptimizer = null;
+		}
+	}
+
+	protected int getStateArrayInitialPosition(MappingModelCreationProcess creationProcess) {
+		// todo (6.0) not sure this is correct in case of SingleTable Inheritance and for Table per class when the selection is the root
+		int stateArrayPosition;
+		if ( superMappingType != null ) {
+			( (InFlightEntityMappingType) superMappingType ).prepareMappingModel( creationProcess );
+			stateArrayPosition = superMappingType.getNumberOfAttributeMappings();
+		}
+		else {
+			stateArrayPosition = 0;
+		}
+		return stateArrayPosition;
+	}
+
+	protected void buildDiscriminatorMapping() {
+		if ( getDiscriminatorType() == null) {
+			discriminatorMapping = null;
+		}
+		else {
+			discriminatorMapping = new EntityDiscriminatorMappingImpl(
+					this,
+					getRootTableName(),
+					getDiscriminatorColumnName(),
+					(BasicType) getDiscriminatorType()
+			);
 		}
 	}
 
@@ -6489,6 +6503,7 @@ public abstract class AbstractEntityPersister
 			EntityMappingType treatTargetType) {
 		if ( treatTargetType == null ) {
 			getStaticFetchableList().forEach( fetchableConsumer );
+//			staticFetchableList.forEach( fetchableConsumer );
 			// EARLY EXIT!!!
 			return;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.ast.tree.from;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.hibernate.LockMode;
+import org.hibernate.NotYetImplementedFor6Exception;
+import org.hibernate.metamodel.mapping.ModelPartContainer;
+import org.hibernate.persister.entity.UnionSubclassEntityPersister;
+import org.hibernate.query.NavigablePath;
+
+/**
+ * @author Andrea Boriero
+ */
+public class UnionTableGroup implements VirtualTableGroup {
+	private final NavigablePath navigablePath;
+
+	private final UnionSubclassEntityPersister modelPart;
+	private final TableReference tableReference;
+
+	public UnionTableGroup(
+			NavigablePath navigablePath,
+			TableReference tableReference,
+			UnionSubclassEntityPersister modelPart) {
+		this.navigablePath = navigablePath;
+		this.tableReference = tableReference;
+		this.modelPart = modelPart;
+	}
+
+	@Override
+	public NavigablePath getNavigablePath() {
+		return navigablePath;
+	}
+
+	@Override
+	public String getGroupAlias() {
+		return null;
+	}
+
+	@Override
+	public ModelPartContainer getModelPart() {
+		return modelPart;
+	}
+
+	@Override
+	public LockMode getLockMode() {
+		return LockMode.NONE;
+	}
+
+	@Override
+	public Set<TableGroupJoin> getTableGroupJoins() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public boolean hasTableGroupJoins() {
+		return false;
+	}
+
+	@Override
+	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
+	}
+
+	@Override
+	public void addTableGroupJoin(TableGroupJoin join) {
+	}
+
+	@Override
+	public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
+	}
+
+	@Override
+	public void applyAffectedTableNames(Consumer<String> nameCollector) {
+	}
+
+	@Override
+	public TableReference getPrimaryTableReference() {
+		return tableReference;
+	}
+
+	@Override
+	public List<TableReferenceJoin> getTableReferenceJoins() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public boolean isInnerJoinPossible() {
+		return false;
+	}
+
+	@Override
+	public TableReference resolveTableReference(
+			String tableExpression, Supplier<TableReference> creator) {
+		return tableReference;
+	}
+
+	@Override
+	public TableReference resolveTableReference(String tableExpression) {
+		return tableReference;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/entity/EntityResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/entity/EntityResultImpl.java
@@ -25,8 +25,6 @@ import org.hibernate.sql.results.spi.EntityResult;
 public class EntityResultImpl extends AbstractEntityResultNode implements EntityResult {
 	private final String resultVariable;
 
-
-
 	public EntityResultImpl(
 			NavigablePath navigablePath,
 			EntityValuedModelPart entityValuedModelPart,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/MixedInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/MixedInheritanceTest.java
@@ -7,13 +7,13 @@
 package org.hibernate.orm.test.metamodel.mapping;
 
 import java.util.List;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
-
-import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.persister.entity.UnionSubclassEntityPersister;
+import javax.persistence.Table;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
@@ -33,47 +33,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @DomainModel(
 		annotatedClasses = {
-				TablePerClassInheritanceWithConcreteRootTest.Customer.class,
-				TablePerClassInheritanceWithConcreteRootTest.DomesticCustomer.class,
-				TablePerClassInheritanceWithConcreteRootTest.ForeignCustomer.class,
-				TablePerClassInheritanceWithConcreteRootTest.Person.class
-
+				MixedInheritanceTest.Customer.class,
+				MixedInheritanceTest.DomesticCustomer.class,
+				MixedInheritanceTest.ForeignCustomer.class,
+				MixedInheritanceTest.Person.class
 		}
 )
 @ServiceRegistry
 @SessionFactory
-public class TablePerClassInheritanceWithConcreteRootTest {
-
-	@Test
-	public void basicTest(SessionFactoryScope scope) {
-		final EntityPersister customerDescriptor = scope.getSessionFactory()
-				.getMetamodel()
-				.findEntityDescriptor( Customer.class );
-		final EntityPersister domesticCustomerDescriptor = scope.getSessionFactory()
-				.getMetamodel()
-				.findEntityDescriptor( DomesticCustomer.class );
-		final EntityPersister foreignCustomerDescriptor = scope.getSessionFactory()
-				.getMetamodel()
-				.findEntityDescriptor( ForeignCustomer.class );
-
-		assert customerDescriptor instanceof UnionSubclassEntityPersister;
-
-		assert customerDescriptor.isTypeOrSuperType( customerDescriptor );
-		assert !customerDescriptor.isTypeOrSuperType( domesticCustomerDescriptor );
-		assert !customerDescriptor.isTypeOrSuperType( foreignCustomerDescriptor );
-
-		assert domesticCustomerDescriptor instanceof UnionSubclassEntityPersister;
-
-		assert domesticCustomerDescriptor.isTypeOrSuperType( customerDescriptor );
-		assert domesticCustomerDescriptor.isTypeOrSuperType( domesticCustomerDescriptor );
-		assert !domesticCustomerDescriptor.isTypeOrSuperType( foreignCustomerDescriptor );
-
-		assert foreignCustomerDescriptor instanceof UnionSubclassEntityPersister;
-
-		assert foreignCustomerDescriptor.isTypeOrSuperType( customerDescriptor );
-		assert !foreignCustomerDescriptor.isTypeOrSuperType( domesticCustomerDescriptor );
-		assert foreignCustomerDescriptor.isTypeOrSuperType( foreignCustomerDescriptor );
-	}
+public class MixedInheritanceTest {
 
 	@Test
 	public void rootQueryExecutionTest(SessionFactoryScope scope) {
@@ -244,7 +212,9 @@ public class TablePerClassInheritanceWithConcreteRootTest {
 	}
 
 	@Entity(name = "Customer")
-	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@Table(name = "customer")
+	@DiscriminatorColumn(name = "cust_type")
 	public static class Customer extends Person {
 
 		private String name;
@@ -268,6 +238,7 @@ public class TablePerClassInheritanceWithConcreteRootTest {
 	}
 
 	@Entity(name = "DomesticCustomer")
+	@DiscriminatorValue("dc")
 	public static class DomesticCustomer extends Customer {
 		private String taxId;
 
@@ -289,6 +260,7 @@ public class TablePerClassInheritanceWithConcreteRootTest {
 	}
 
 	@Entity(name = "ForeignCustomer")
+	@DiscriminatorValue("fc")
 	public static class ForeignCustomer extends Customer {
 		private String vat;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/TablePerClassInheritanceWithAbstractRootTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/TablePerClassInheritanceWithAbstractRootTest.java
@@ -16,7 +16,6 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.UnionSubclassEntityPersister;
 
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.FailureExpected;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -34,14 +33,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @DomainModel(
 		annotatedClasses = {
-				TablePerClassInheritanceTest.Customer.class,
-				TablePerClassInheritanceTest.DomesticCustomer.class,
-				TablePerClassInheritanceTest.ForeignCustomer.class
+				TablePerClassInheritanceWithAbstractRootTest.Customer.class,
+				TablePerClassInheritanceWithAbstractRootTest.DomesticCustomer.class,
+				TablePerClassInheritanceWithAbstractRootTest.ForeignCustomer.class
 		}
 )
 @ServiceRegistry
 @SessionFactory
-public class TablePerClassInheritanceTest {
+public class TablePerClassInheritanceWithAbstractRootTest {
 
 	@Test
 	public void basicTest(SessionFactoryScope scope) {
@@ -75,7 +74,6 @@ public class TablePerClassInheritanceTest {
 	}
 
 	@Test
-	@FailureExpected
 	public void rootQueryExecutionTest(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -109,7 +107,6 @@ public class TablePerClassInheritanceTest {
 	}
 
 	@Test
-	@FailureExpected
 	public void subclassQueryExecutionTest(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -140,7 +137,7 @@ public class TablePerClassInheritanceTest {
 		);
 	}
 
-//	@BeforeEach
+	@BeforeEach
 	public void createTestData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -150,7 +147,7 @@ public class TablePerClassInheritanceTest {
 		);
 	}
 
-//	@AfterEach
+	@AfterEach
 	public void cleanupTestData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/TablePerClassInheritanceWithConcreteRootTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/TablePerClassInheritanceWithConcreteRootTest.java
@@ -1,0 +1,240 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.metamodel.mapping;
+
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.persister.entity.UnionSubclassEntityPersister;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@DomainModel(
+		annotatedClasses = {
+				TablePerClassInheritanceWithConcreteRootTest.Customer.class,
+				TablePerClassInheritanceWithConcreteRootTest.DomesticCustomer.class,
+				TablePerClassInheritanceWithConcreteRootTest.ForeignCustomer.class
+		}
+)
+@ServiceRegistry
+@SessionFactory
+public class TablePerClassInheritanceWithConcreteRootTest {
+
+	@Test
+	public void basicTest(SessionFactoryScope scope) {
+		final EntityPersister customerDescriptor = scope.getSessionFactory()
+				.getMetamodel()
+				.findEntityDescriptor( Customer.class );
+		final EntityPersister domesticCustomerDescriptor = scope.getSessionFactory()
+				.getMetamodel()
+				.findEntityDescriptor( DomesticCustomer.class );
+		final EntityPersister foreignCustomerDescriptor = scope.getSessionFactory()
+				.getMetamodel()
+				.findEntityDescriptor( ForeignCustomer.class );
+
+		assert customerDescriptor instanceof UnionSubclassEntityPersister;
+
+		assert customerDescriptor.isTypeOrSuperType( customerDescriptor );
+		assert !customerDescriptor.isTypeOrSuperType( domesticCustomerDescriptor );
+		assert !customerDescriptor.isTypeOrSuperType( foreignCustomerDescriptor );
+
+		assert domesticCustomerDescriptor instanceof UnionSubclassEntityPersister;
+
+		assert domesticCustomerDescriptor.isTypeOrSuperType( customerDescriptor );
+		assert domesticCustomerDescriptor.isTypeOrSuperType( domesticCustomerDescriptor );
+		assert !domesticCustomerDescriptor.isTypeOrSuperType( foreignCustomerDescriptor );
+
+		assert foreignCustomerDescriptor instanceof UnionSubclassEntityPersister;
+
+		assert foreignCustomerDescriptor.isTypeOrSuperType( customerDescriptor );
+		assert !foreignCustomerDescriptor.isTypeOrSuperType( domesticCustomerDescriptor );
+		assert foreignCustomerDescriptor.isTypeOrSuperType( foreignCustomerDescriptor );
+	}
+
+	@Test
+	public void rootQueryExecutionTest(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					{
+						// [name, taxId, vat]
+						final List<Customer> results = session.createQuery(
+								"select c from Customer c",
+								Customer.class
+						).list();
+
+						assertThat( results.size(), is( 3 ) );
+
+						for ( Customer result : results ) {
+							if ( result.getId() == 1 ) {
+								assertThat( result, instanceOf( DomesticCustomer.class ) );
+								final DomesticCustomer customer = (DomesticCustomer) result;
+								assertThat( customer.getName(), is( "domestic" ) );
+								assertThat( ( customer ).getTaxId(), is( "123" ) );
+							}
+							else if ( result.getId() == 2 ) {
+								assertThat( result.getId(), is( 2 ) );
+								final ForeignCustomer customer = (ForeignCustomer) result;
+								assertThat( customer.getName(), is( "foreign" ) );
+								assertThat( ( customer ).getVat(), is( "987" ) );
+							}
+							else {
+								assertThat( result.getId(), is( 3 ) );
+								final Customer customer = result;
+								assertThat( customer.getName(), is( "customer" ) );
+							}
+						}
+
+					}
+				}
+		);
+	}
+
+	@Test
+	public void subclassQueryExecutionTest(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					{
+						final DomesticCustomer result = session.createQuery(
+								"select c from DomesticCustomer c",
+								DomesticCustomer.class
+						).uniqueResult();
+
+						assertThat( result, notNullValue() );
+						assertThat( result.getId(), is( 1 ) );
+						assertThat( result.getName(), is( "domestic" ) );
+						assertThat( result.getTaxId(), is( "123" ) );
+					}
+
+					{
+						final ForeignCustomer result = session.createQuery(
+								"select c from ForeignCustomer c",
+								ForeignCustomer.class
+						).uniqueResult();
+
+						assertThat( result, notNullValue() );
+						assertThat( result.getId(), is( 2 ) );
+						assertThat( result.getName(), is( "foreign" ) );
+						assertThat( result.getVat(), is( "987" ) );
+					}
+				}
+		);
+	}
+
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.persist( new Customer( 3, "customer" ) );
+					session.persist( new DomesticCustomer( 1, "domestic", "123" ) );
+					session.persist( new ForeignCustomer( 2, "foreign", "987" ) );
+				}
+		);
+	}
+
+	@AfterEach
+	public void cleanupTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "from Customer", Customer.class ).list().forEach(
+							cust -> session.delete( cust )
+					);
+				}
+		);
+	}
+
+	@Entity(name = "Customer")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static class Customer {
+		private Integer id;
+		private String name;
+
+		public Customer() {
+		}
+
+		public Customer(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "DomesticCustomer")
+	public static class DomesticCustomer extends Customer {
+		private String taxId;
+
+		public DomesticCustomer() {
+		}
+
+		public DomesticCustomer(Integer id, String name, String taxId) {
+			super( id, name );
+			this.taxId = taxId;
+		}
+
+		public String getTaxId() {
+			return taxId;
+		}
+
+		public void setTaxId(String taxId) {
+			this.taxId = taxId;
+		}
+	}
+
+	@Entity(name = "ForeignCustomer")
+	public static class ForeignCustomer extends Customer {
+		private String vat;
+
+		public ForeignCustomer() {
+		}
+
+		public ForeignCustomer(Integer id, String name, String vat) {
+			super( id, name );
+			this.vat = vat;
+		}
+
+		public String getVat() {
+			return vat;
+		}
+
+		public void setVat(String vat) {
+			this.vat = vat;
+		}
+	}
+}


### PR DESCRIPTION
Hi @sebersole,

this is an initial work for the TABLE_PER_CLASS inheritance, at the moment for the sql select union fragment I'm still using the one generated by the `UnionSubclassEntityPersister#generateSubquery()` but probably we have to create a proper AST instead and use it to create the sql select union fragment.